### PR TITLE
Stop pgbot from counting its own footprint as the database's; fix build, wait sampler, and a few reporting bugs

### DIFF
--- a/cmd/pgbot/explain.go
+++ b/cmd/pgbot/explain.go
@@ -108,7 +108,7 @@ func runExplain(cmd *cobra.Command, args []string, f inspectFlags, yes bool) err
 	if !f.noStore {
 		trends, baselinePath = withStore(f.storePath, c)
 	}
-	if err := computeFindings(c, f.config, f.ignore); err != nil {
+	if err := computeFindings(c, f); err != nil {
 		return err
 	}
 

--- a/cmd/pgbot/gather.go
+++ b/cmd/pgbot/gather.go
@@ -41,7 +41,7 @@ func gather(ctx context.Context, connString string, f inspectFlags) (*model.Cont
 	if !f.noStore {
 		withStore(f.storePath, c)
 	}
-	if err := computeFindings(c, f.config, f.ignore); err != nil {
+	if err := computeFindings(c, f); err != nil {
 		return nil, "", err
 	}
 	return c, host, nil

--- a/cmd/pgbot/inspect.go
+++ b/cmd/pgbot/inspect.go
@@ -128,7 +128,7 @@ func runInspect(cmd *cobra.Command, args []string, f inspectFlags) error {
 	// Deterministic findings — computed in Go, never by a model. Under the active
 	// .pgbot.toml: threshold overrides feed the compute, severity/ignore rules are
 	// applied, suppressed findings are kept (marked) for the renderer.
-	if err := computeFindings(c, f.config, f.ignore); err != nil {
+	if err := computeFindings(c, f); err != nil {
 		return err
 	}
 

--- a/cmd/pgbot/mcp.go
+++ b/cmd/pgbot/mcp.go
@@ -269,7 +269,7 @@ func vacuumHealthTool(ctx context.Context, args json.RawMessage) (string, error)
 	past := 0
 	rows := make([]map[string]any, 0, len(tbls))
 	for _, t := range tbls {
-		due := expectAutovacuum(t.LiveTuples, t.DeadTuples)
+		due := expectAutovacuum(t, avVacThreshold(c), avVacScale(c))
 		if due {
 			past++
 		}

--- a/cmd/pgbot/queries.go
+++ b/cmd/pgbot/queries.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -119,9 +120,18 @@ func humanCount(n int64) string {
 	}
 }
 
+// truncStr collapses every run of whitespace (normalized query text is
+// multi-line and would break a tabwriter row) to a single space, then truncates
+// to n runes — slicing bytes could split a multi-byte rune and emit invalid
+// UTF-8.
 func truncStr(s string, n int) string {
-	if len(s) <= n {
+	s = strings.Join(strings.Fields(s), " ")
+	r := []rune(s)
+	if len(r) <= n {
 		return s
 	}
-	return s[:n-1] + "…"
+	if n < 1 {
+		return "…"
+	}
+	return string(r[:n-1]) + "…"
 }

--- a/cmd/pgbot/queries_test.go
+++ b/cmd/pgbot/queries_test.go
@@ -57,4 +57,16 @@ func TestTruncStr(t *testing.T) {
 	if got[len(got)-len("…"):] != "…" {
 		t.Errorf("truncated string should end with ellipsis, got %q", got)
 	}
+	// normalized query text is multi-line with runs of spaces: collapse to one
+	// space so it never breaks a tabwriter row.
+	if got := truncStr("SELECT\n    l.city,\n    l.country", 18); got != "SELECT l.city, l.…" {
+		t.Errorf("whitespace not collapsed: %q", got)
+	}
+	// truncation is rune-safe: café's é is 2 bytes; a byte slice would corrupt it.
+	if got := truncStr("café society", 5); got != "café…" {
+		t.Errorf("rune-safe truncation failed: %q", got)
+	}
+	if got := truncStr("abc", 1); got != "…" {
+		t.Errorf("n<1 edge: %q", got)
+	}
 }

--- a/cmd/pgbot/vacuum.go
+++ b/cmd/pgbot/vacuum.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"text/tabwriter"
 	"time"
 
@@ -69,9 +70,15 @@ func runVacuum(cmd *cobra.Command, args []string, f inspectFlags) error {
 	tbls := append([]model.TableStat(nil), c.Tables.Top...)
 	sort.SliceStable(tbls, func(i, j int) bool { return tbls[i].DeadTuples > tbls[j].DeadTuples })
 
+	// The trigger is threshold + scale × live_tuples, from the cluster GUCs
+	// (collected in the settings tuning set) with per-table reloptions taking
+	// precedence. Fall back to Postgres' compiled defaults if settings are absent.
+	gThreshold := settingFloat(c, "autovacuum_vacuum_threshold", avDefaultThreshold)
+	gScale := settingFloat(c, "autovacuum_vacuum_scale_factor", avDefaultScaleFactor)
+
 	behind := 0
 	for _, t := range tbls {
-		if expectAutovacuum(t.LiveTuples, t.DeadTuples) {
+		if expectAutovacuum(t, gThreshold, gScale) {
 			behind++
 		}
 	}
@@ -86,7 +93,7 @@ func runVacuum(cmd *cobra.Command, args []string, f inspectFlags) error {
 	fmt.Fprintln(tw, "  table\tlive\tdead\tdead%\tlast autovacuum\tdue?")
 	for _, t := range tbls {
 		due := st.Dim("no")
-		if expectAutovacuum(t.LiveTuples, t.DeadTuples) {
+		if expectAutovacuum(t, gThreshold, gScale) {
 			due = st.Warn("yes")
 		}
 		name := t.Schema + "." + t.Name
@@ -96,13 +103,51 @@ func runVacuum(cmd *cobra.Command, args []string, f inspectFlags) error {
 	}
 	tw.Flush()
 	fmt.Println()
-	fmt.Println(st.Dim("due? = dead tuples past Postgres' default autovacuum trigger (50 + 20% of live rows)."))
+	fmt.Println(st.Dim(fmt.Sprintf("due? = dead tuples past the autovacuum trigger (threshold %.0f + %.0f%% of live rows; per-table overrides applied).",
+		gThreshold, gScale*100)))
 	fmt.Println(st.Dim("tables ranked by dead tuples, from the 30 largest by size."))
 	return nil
 }
 
-func expectAutovacuum(live, dead int64) bool {
-	return float64(dead) > avDefaultThreshold+avDefaultScaleFactor*float64(live)
+// expectAutovacuum reports whether a table's dead tuples have passed its
+// autovacuum trigger. Per-table reloptions win over the cluster defaults passed
+// in; a table with autovacuum_enabled=false will never be autovacuumed, so it is
+// never "due" (that is the autovacuum_disabled finding's job, not this column's).
+func expectAutovacuum(t model.TableStat, gThreshold, gScale float64) bool {
+	if t.AutovacuumDisabled {
+		return false
+	}
+	threshold, scale := gThreshold, gScale
+	if t.VacuumThresholdOverride != nil {
+		threshold = *t.VacuumThresholdOverride
+	}
+	if t.VacuumScaleOverride != nil {
+		scale = *t.VacuumScaleOverride
+	}
+	return float64(t.DeadTuples) > threshold+scale*float64(t.LiveTuples)
+}
+
+// avVacThreshold / avVacScale are the cluster autovacuum trigger knobs (with the
+// compiled-in defaults as fallback), shared by the vacuum command and the MCP
+// vacuum_health tool so both grade "due" the same way.
+func avVacThreshold(c *model.Context) float64 {
+	return settingFloat(c, "autovacuum_vacuum_threshold", avDefaultThreshold)
+}
+func avVacScale(c *model.Context) float64 {
+	return settingFloat(c, "autovacuum_vacuum_scale_factor", avDefaultScaleFactor)
+}
+
+// settingFloat reads a numeric parameter from the collected settings, or def.
+func settingFloat(c *model.Context, name string, def float64) float64 {
+	if c.Settings == nil {
+		return def
+	}
+	if v, ok := c.Settings.Params[name]; ok {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return def
 }
 
 // agoStr renders how long ago a timestamp was, or "never" if unset.

--- a/cmd/pgbot/vacuum_test.go
+++ b/cmd/pgbot/vacuum_test.go
@@ -3,23 +3,36 @@ package main
 import (
 	"testing"
 	"time"
+
+	"github.com/pgrundev/pgbot/internal/model"
 )
 
 func TestExpectAutovacuum(t *testing.T) {
+	const th, sc = avDefaultThreshold, avDefaultScaleFactor
+	f := func(v float64) *float64 { return &v }
 	cases := []struct {
+		name       string
 		live, dead int64
+		disabled   bool
+		thOver     *float64
+		scOver     *float64
 		want       bool
 	}{
-		{0, 50, false},      // exactly at threshold — not yet past
-		{0, 51, true},       // one over the base threshold of 50
-		{1000, 200, false},  // 200 < 50 + 0.2*1000 = 250
-		{1000, 300, true},   // 300 > 250
-		{100000, 20000, false},
-		{100000, 20100, true}, // 20100 > 50 + 20000
+		{"at base threshold", 0, 50, false, nil, nil, false},
+		{"one over base", 0, 51, false, nil, nil, true},
+		{"under default trigger", 1000, 200, false, nil, nil, false}, // 200 < 50 + 0.2*1000
+		{"over default trigger", 1000, 300, false, nil, nil, true},
+		{"large under", 100000, 20000, false, nil, nil, false},
+		{"large over", 100000, 20100, false, nil, nil, true},
+		{"autovacuum disabled is never due", 1000, 999999, true, nil, nil, false},
+		{"per-table scale override raises the bar", 1000, 300, false, nil, f(0.5), false}, // 300 < 50 + 0.5*1000
+		{"per-table threshold override lowers it", 0, 30, false, f(20), nil, true},        // 30 > 20
 	}
 	for _, c := range cases {
-		if got := expectAutovacuum(c.live, c.dead); got != c.want {
-			t.Errorf("expectAutovacuum(live=%d, dead=%d) = %v, want %v", c.live, c.dead, got, c.want)
+		ts := model.TableStat{LiveTuples: c.live, DeadTuples: c.dead, AutovacuumDisabled: c.disabled,
+			VacuumThresholdOverride: c.thOver, VacuumScaleOverride: c.scOver}
+		if got := expectAutovacuum(ts, th, sc); got != c.want {
+			t.Errorf("%s: expectAutovacuum(live=%d, dead=%d) = %v, want %v", c.name, c.live, c.dead, got, c.want)
 		}
 	}
 }

--- a/internal/collect/activity.go
+++ b/internal/collect/activity.go
@@ -88,8 +88,14 @@ func (activityCollector) Assemble(c *model.Context, _ conn.Capabilities, s sampl
 			act.IdleInTransaction += r.N
 		}
 		if r.WaitEventType != "" {
-			act.Waiting += r.N
 			act.WaitEvents[r.WaitEventType] += r.N
+			// "Waiting" means blocked on something inside the server (Lock, IO,
+			// LWLock, …). An idle backend always shows wait_event_type='Client'
+			// (ClientRead: waiting for the application to send the next query) —
+			// counting it would make every idle connection "waiting".
+			if r.WaitEventType != "Client" {
+				act.Waiting += r.N
+			}
 		}
 		if r.MaxXactAgeS > act.LongestXactSec {
 			act.LongestXactSec = round2(r.MaxXactAgeS)

--- a/internal/collect/ash.go
+++ b/internal/collect/ash.go
@@ -22,8 +22,10 @@ type WaitSample struct {
 	AppName       string  `db:"app_name"`
 }
 
-// ashSQL selects the currently-active non-self backends. query_id is PG14+; on
-// older servers we select a NULL literal so the column reference never errors.
+// ashSQL selects the currently-active backends that are not pgbot's own — the
+// pool's collectors run concurrently with the sampler and would otherwise show
+// up as CPU/IO samples. query_id is PG14+; on older servers we select a NULL
+// literal so the column reference never errors.
 func ashSQL(caps conn.Capabilities) string {
 	qid := "NULL::bigint"
 	if caps.VersionNum >= 140000 {
@@ -32,7 +34,7 @@ func ashSQL(caps conn.Capabilities) string {
 	return `SELECT pid, state, wait_event_type, wait_event, ` + qid + ` AS query_id,
 	               backend_type, coalesce(application_name, '') AS app_name
 	        FROM pg_stat_activity
-	        WHERE state = 'active' AND pid <> pg_backend_pid()`
+	        WHERE state = 'active' AND application_name IS DISTINCT FROM 'pgbot'`
 }
 
 // ashResult is what one sampling window produced. attempts/failures let the

--- a/internal/collect/ash.go
+++ b/internal/collect/ash.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/pgrundev/pgbot/internal/conn"
 	"github.com/pgrundev/pgbot/internal/model"
 )
@@ -48,10 +49,23 @@ type ashResult struct {
 	failures int
 }
 
-// sampleWaits polls active backends at hz for the window, each poll its own
-// short read-only transaction. A poll that errors or times out is dropped and
-// sampling continues — the sampler must never fail the run or queue behind a
-// lock storm.
+// ashPollBudget is the per-poll deadline. It is deliberately NOT the tick
+// interval: at the default 10 Hz that would be 100 ms, and a poll over a
+// normal-latency link (a laptop or CI reaching RDS/Neon/Supabase at 30–100 ms
+// RTT) cannot complete in that — every poll timed out, every timeout tore down
+// its pool connection (pgx closes a connection whose context expires
+// mid-query) and rolled back a transaction, and the profile came back
+// "all N polls errored" while the terminal report said nothing. With a fixed
+// budget the sampler runs at min(hz, what the round trip allows) instead of 0.
+const ashPollBudget = time.Second
+
+// sampleWaits polls active backends at hz for the window. Each poll is one
+// round trip (a bare SELECT — every pgbot session is default_transaction_
+// read_only=on, and pg_stat_activity is live, so there is nothing an explicit
+// transaction adds but two more round trips and an idle-in-transaction gap). A
+// poll that errors or times out is dropped and sampling continues — the sampler
+// must never fail the run or queue behind a lock storm. Polls run
+// back-to-back; a tick that fires while one is in flight is simply skipped.
 func sampleWaits(ctx context.Context, t *conn.Target, caps conn.Capabilities, hz int, window time.Duration) ashResult {
 	if hz <= 0 || window <= 0 {
 		return ashResult{}
@@ -64,15 +78,20 @@ func sampleWaits(ctx context.Context, t *conn.Target, caps conn.Capabilities, hz
 	res := ashResult{}
 	poll := func() {
 		// Each poll gets its own budget so a stalled read is abandoned, not queued.
-		pctx, cancel := context.WithTimeout(ctx, interval)
+		pctx, cancel := context.WithTimeout(ctx, ashPollBudget)
 		defer cancel()
 		res.attempts++
-		rows, err := queryMany[WaitSample](pctx, t, sql)
+		rows, err := t.Pool.Query(pctx, sql)
 		if err != nil {
 			res.failures++ // drop this poll, keep going
 			return
 		}
-		res.samples = append(res.samples, rows...)
+		got, err := pgx.CollectRows(rows, pgx.RowToStructByNameLax[WaitSample])
+		if err != nil {
+			res.failures++
+			return
+		}
+		res.samples = append(res.samples, got...)
 	}
 
 	ticker := time.NewTicker(interval)

--- a/internal/collect/collector.go
+++ b/internal/collect/collector.go
@@ -151,8 +151,19 @@ func queryOne[T any](ctx context.Context, t *conn.Target, sql string, args ...an
 }
 
 func queryMany[T any](ctx context.Context, t *conn.Target, sql string, args ...any) ([]T, error) {
+	return queryManyLocal[T](ctx, t, nil, sql, args...)
+}
+
+// queryManyLocal is queryMany with transaction-local SET statements run first
+// (SET LOCAL … — they end with the transaction, so the session's pins stay).
+func queryManyLocal[T any](ctx context.Context, t *conn.Target, setLocal []string, sql string, args ...any) ([]T, error) {
 	var out []T
 	err := t.ReadOnlyTx(ctx, func(tx pgx.Tx) error {
+		for _, s := range setLocal {
+			if _, err := tx.Exec(ctx, s); err != nil {
+				return err
+			}
+		}
 		rows, err := tx.Query(ctx, sql, args...)
 		if err != nil {
 			return err

--- a/internal/collect/collector.go
+++ b/internal/collect/collector.go
@@ -56,6 +56,10 @@ type sampled struct {
 	A   any
 	B   any
 	Err error
+	// OwnTxns is how many transactions pgbot itself committed inside the sample
+	// window [A, B] — the wait sampler's successful polls. Only the health
+	// collector receives it, and subtracts it from the commit delta.
+	OwnTxns int64
 }
 
 // Collector reads one diagnostic domain and writes its section into the Context.

--- a/internal/collect/health.go
+++ b/internal/collect/health.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/pgrundev/pgbot/internal/conn"
 	"github.com/pgrundev/pgbot/internal/model"
 	"github.com/pgrundev/pgbot/internal/rate"
@@ -41,7 +42,16 @@ func (healthCollector) Kind() Kind                       { return KindCounter }
 func (healthCollector) Available(conn.Capabilities) bool { return true }
 
 func (healthCollector) Sample(ctx context.Context, t *conn.Target, _ conn.Capabilities) (any, error) {
-	return queryOne[healthSample](ctx, t, sqlHealth)
+	// A single-row read on an already-read-only session — run it directly on the
+	// pool (one round trip) rather than wrapping it in BEGIN/COMMIT (three). The
+	// window is bracketed by two of these serially (runner.go), so the round
+	// trips are on the critical path; the saved transactions are also two fewer
+	// of pgbot's own commits per run.
+	rows, err := t.Pool.Query(ctx, sqlHealth)
+	if err != nil {
+		return healthSample{}, err
+	}
+	return pgx.CollectExactlyOneRow(rows, pgx.RowToStructByNameLax[healthSample])
 }
 
 func (healthCollector) Assemble(c *model.Context, _ conn.Capabilities, s sampled, dt time.Duration, _ Options) {

--- a/internal/collect/health.go
+++ b/internal/collect/health.go
@@ -32,7 +32,11 @@ type healthSample struct {
 	StatsReset   *time.Time `db:"stats_reset"`
 }
 
-func (healthCollector) Name() string                     { return "health" }
+// healthName is the registry name the runner uses to sequence this collector
+// around the sample window (see Run).
+const healthName = "health"
+
+func (healthCollector) Name() string                     { return healthName }
 func (healthCollector) Kind() Kind                       { return KindCounter }
 func (healthCollector) Available(conn.Capabilities) bool { return true }
 
@@ -56,10 +60,17 @@ func (healthCollector) Assemble(c *model.Context, _ conn.Capabilities, s sampled
 		}
 		return v
 	}
-	h.TPS = mark(rate.PerSecond(a.XactCommit+a.XactRollback, b.XactCommit+b.XactRollback, dt))
-	h.CommitsPerSec = mark(rate.PerSecond(a.XactCommit, b.XactCommit, dt))
+	// pgbot's own commits inside the window (the wait sampler's polls) are not
+	// the database's throughput: take them off sample B's commit counter before
+	// computing rates. Clamped so a reset (b < a) is still detected as such.
+	commitsB := b.XactCommit
+	if own := s.OwnTxns; own > 0 && commitsB-own >= a.XactCommit {
+		commitsB -= own
+	}
+	h.TPS = mark(rate.PerSecond(a.XactCommit+a.XactRollback, commitsB+b.XactRollback, dt))
+	h.CommitsPerSec = mark(rate.PerSecond(a.XactCommit, commitsB, dt))
 	h.RollbacksPerSec = mark(rate.PerSecond(a.XactRollback, b.XactRollback, dt))
-	if rr, ok := rate.Ratio(a.XactRollback, b.XactRollback, a.XactCommit, b.XactCommit); ok {
+	if rr, ok := rate.Ratio(a.XactRollback, b.XactRollback, a.XactCommit, commitsB); ok {
 		h.RollbackRatio = round4p(rr)
 	}
 	if chr, ok := rate.Ratio(a.BlksHit, b.BlksHit, a.BlksRead, b.BlksRead); ok {

--- a/internal/collect/health.go
+++ b/internal/collect/health.go
@@ -64,6 +64,8 @@ func (healthCollector) Assemble(c *model.Context, _ conn.Capabilities, s sampled
 	}
 	if chr, ok := rate.Ratio(a.BlksHit, b.BlksHit, a.BlksRead, b.BlksRead); ok {
 		h.CacheHitRatio = round4p(chr)
+		blocks := (b.BlksHit + b.BlksRead) - (a.BlksHit + a.BlksRead)
+		h.CacheBlocks = &blocks
 	}
 	if d, ok := rate.PerSecond(a.Deadlocks, b.Deadlocks, dt); ok {
 		h.DeadlocksPerMin = rate.Ptr(round2(*d * 60))

--- a/internal/collect/indexes.go
+++ b/internal/collect/indexes.go
@@ -61,6 +61,7 @@ type indexesSample struct {
 	Rows      []indexRow
 	Redundant []redundantRow
 	FKs       []fkRow
+	Total     int // count of ALL user indexes, not just the scanned window
 }
 
 func (indexesCollector) Sample(ctx context.Context, t *conn.Target, _ conn.Capabilities) (any, error) {
@@ -69,6 +70,10 @@ func (indexesCollector) Sample(ctx context.Context, t *conn.Target, _ conn.Capab
 		return nil, err
 	}
 	out := indexesSample{Rows: rows}
+	// indexes.sql is LIMIT 200 (the largest, for the list). Total is the real
+	// user-index count so the report says "398 total" not "200 total"; anything
+	// unused below the 200-largest cut is small and out of scope for the finding.
+	out.Total, _ = scalar[int](ctx, t, `SELECT count(*)::int FROM pg_stat_user_indexes`)
 	// Redundant-index and unindexed-FK detection are pure catalog reads; a failure
 	// in either must not sink the whole indexes section (it degrades to no list).
 	out.Redundant, _ = queryMany[redundantRow](ctx, t, sqlRedundantIndexes)
@@ -83,7 +88,11 @@ func (indexesCollector) Assemble(c *model.Context, _ conn.Capabilities, s sample
 		return
 	}
 	rows := sm.Rows
-	idx := &model.Indexes{Section: model.Section{Exactness: model.ExactnessScraped}, Total: len(rows)}
+	total := sm.Total
+	if total == 0 {
+		total = len(rows) // count query failed — fall back to what we scanned
+	}
+	idx := &model.Indexes{Section: model.Section{Exactness: model.ExactnessScraped}, Total: total, Scanned: len(rows)}
 	for _, r := range sm.Redundant {
 		idx.Redundant = append(idx.Redundant, model.RedundantIndex{
 			Schema: r.Schema, Table: r.Table, Name: r.Redundant, CoveredBy: r.Covering, Bytes: r.Bytes,

--- a/internal/collect/integration_test.go
+++ b/internal/collect/integration_test.go
@@ -102,6 +102,25 @@ func TestIntegration_fullPipeline(t *testing.T) {
 		t.Error("horizon section missing exactness label")
 	}
 
+	// Self-observation gates: pgbot's own sessions and session pins must not
+	// leak into what it reports about the database.
+	if c.Activity != nil {
+		if c.Activity.IdleInTransaction != 0 && os.Getenv("PGBOT_TEST_LOAD") == "" {
+			t.Errorf("idle_in_transaction = %d on an idle test database — pgbot is counting its own pool", c.Activity.IdleInTransaction)
+		}
+	}
+	if c.Settings != nil {
+		for _, pin := range []string{"statement_timeout", "lock_timeout", "idle_in_transaction_session_timeout",
+			"default_transaction_read_only", "stats_fetch_consistency", "application_name"} {
+			if v, ok := c.Settings.Overrides[pin]; ok {
+				t.Errorf("settings.overrides reports pgbot's own session pin %s=%s as server config", pin, v)
+			}
+		}
+		if got := c.Settings.Params["statement_timeout"]; got == "15s" {
+			t.Errorf("settings.params.statement_timeout = %q — that is pgbot's session pin, not the server value", got)
+		}
+	}
+
 	// PII gate: render JSON and assert no email/uuid leaked from a fake-data table.
 	// (The caller is expected to have seeded such data; we assert the invariant
 	// regardless — scrubbing must hold, and pgss text is normalized.)

--- a/internal/collect/queries.go
+++ b/internal/collect/queries.go
@@ -52,12 +52,24 @@ type queriesSample struct {
 func (queriesCollector) Sample(ctx context.Context, t *conn.Target, caps conn.Capabilities) (any, error) {
 	// The version-appropriate total-time column comes from a fixed allowlist
 	// (never user input); %% in the SQL escapes the ILIKE literal.
-	rows, err := queryMany[queryRow](ctx, t, fmt.Sprintf(sqlQueries, caps.StatStatementsTotalCol()))
+	//
+	// pg_stat_statements is a set-returning function: every row (with up to
+	// 4 KB of query text) is materialized in a tuplestore before ORDER BY/LIMIT,
+	// and the window sum() OVER () keeps all of them. At the default
+	// work_mem=4MB and ~5k tracked statements that is ~5 MB of temp file per
+	// pgbot run — landing inside pgbot's own sample window, where the health
+	// collector reads it back as temp_bytes_per_sec ≈ 1 MiB/s and the tune rule
+	// recommends raising work_mem for it. A transaction-local work_mem keeps
+	// this read in memory (measured: temp written=612 blocks → 0).
+	rows, err := queryManyLocal[queryRow](ctx, t, []string{"SET LOCAL work_mem = '64MB'"},
+		fmt.Sprintf(sqlQueries, caps.StatStatementsTotalCol()))
 	if err != nil {
 		return nil, err
 	}
 	out := queriesSample{Rows: rows}
-	out.Count, _ = scalar[int](ctx, t, `SELECT count(*)::int FROM pg_stat_statements`)
+	// showtext := false — counting through the view materializes every row WITH
+	// its query text (the same ~5 MB tuplestore/temp file as above, for a count).
+	out.Count, _ = scalar[int](ctx, t, `SELECT count(*)::int FROM pg_stat_statements(false)`)
 	if m, err := scalar[int](ctx, t, `SELECT current_setting('pg_stat_statements.max')::int`); err == nil {
 		out.Max = m
 	}

--- a/internal/collect/runner.go
+++ b/internal/collect/runner.go
@@ -137,7 +137,7 @@ func Run(ctx context.Context, t *conn.Target, opts Options) (*model.Context, err
 		<-ashDone
 		out.WaitProfile = profileFrom(ash, queryTexts(out))
 	} else {
-		out.WaitProfile = &model.WaitProfile{Available: false, Reason: "sampler disabled (--ash-hz 0)"}
+		out.WaitProfile = &model.WaitProfile{Available: false, Reason: model.WaitSamplerDisabledReason}
 	}
 	return out, nil
 }

--- a/internal/collect/runner.go
+++ b/internal/collect/runner.go
@@ -14,12 +14,22 @@ import (
 // first counter sample are read in phase 1; the second counter sample after the
 // interval in phase 2. A single failing collector marks its section unavailable
 // rather than failing the run.
+//
+// The sample window — the slice of wall-clock time every per-second rate
+// describes — is opened by the health collector's sample A and closed by its
+// sample B, and pgbot keeps its own footprint out of it: every other collector
+// runs before A (phase 1) or after B (phase 2), and the only thing that runs
+// inside is the wait sampler, whose successful polls are counted and subtracted
+// from the commit delta (sampled.OwnTxns). Without that, phase 1's own
+// statements (each SET on a fresh connection is a committed implicit
+// transaction) and up to hz×window sampler polls were read back as the
+// database's TPS — several tps on a quiet server, i.e. the entire figure.
 func Run(ctx context.Context, t *conn.Target, opts Options) (*model.Context, error) {
 	iv := opts.interval()
-	// The active-session sampler (T8) defines the window: it runs concurrently
-	// with the whole two-phase counter collection, polling pg_stat_activity at
-	// ashHz for ashWindow. Stretch the counter interval to cover its window so
-	// both signals describe the same slice of wall-clock time.
+	// The active-session sampler (T8) defines the window: it polls
+	// pg_stat_activity at ashHz for ashWindow, inside [A, B]. Stretch the
+	// counter interval to cover its window so both signals describe the same
+	// slice of wall-clock time.
 	ashOn := opts.ashHz() > 0
 	if ashOn && opts.ashWindow() > iv {
 		iv = opts.ashWindow()
@@ -40,18 +50,12 @@ func Run(ctx context.Context, t *conn.Target, opts Options) (*model.Context, err
 	results := make(map[string]*sampled, len(registry))
 
 	// The sampler never fails the run — a dead sampler just yields an unavailable
-	// profile. Launch it before phase 1 so its window brackets the counters.
+	// profile. It is launched right after sample A (below) so its polls are the
+	// only pgbot traffic inside the window.
 	var (
 		ash     ashResult
 		ashDone chan struct{}
 	)
-	if ashOn {
-		ashDone = make(chan struct{})
-		go func() {
-			defer close(ashDone)
-			ash = sampleWaits(ctx, t, caps, opts.ashHz(), opts.ashWindow())
-		}()
-	}
 	// Guarantee the sampler goroutine has fully exited before Run returns — on
 	// EVERY path, including the mid-run cancellation returns below. sampleWaits
 	// watches ctx.Done(), so cancel first (idempotent with the deferred cancel
@@ -64,13 +68,16 @@ func Run(ctx context.Context, t *conn.Target, opts Options) (*model.Context, err
 		}
 	}()
 
-	// Phase 1: sample A for every available collector (counters and gauges),
-	// concurrently and bounded to the pool.
-	tA := nowUTC()
+	// Phase 1: sample A for every available collector except health (gauges and
+	// the other counters), concurrently and bounded to the pool. This is where
+	// pool connections get established (and pinned) — all of it before the window.
 	g1, gctx := errgroup.WithContext(ctx)
 	g1.SetLimit(4)
 	for _, c := range registry {
 		c := c
+		if c.Name() == healthName {
+			continue
+		}
 		if !c.Available(caps) {
 			mu.Lock()
 			results[c.Name()] = &sampled{}
@@ -87,20 +94,42 @@ func Run(ctx context.Context, t *conn.Target, opts Options) (*model.Context, err
 	}
 	_ = g1.Wait()
 
-	// Wait out the sample interval, then re-read the counters (sample B).
+	// Sample A opens the window.
+	health := healthCollector{}
+	hA, hErr := health.Sample(ctx, t, caps)
+	tA := nowUTC()
+	if ashOn {
+		ashDone = make(chan struct{})
+		go func() {
+			defer close(ashDone)
+			ash = sampleWaits(ctx, t, caps, opts.ashHz(), opts.ashWindow())
+		}()
+	}
+
+	// Wait out the sample interval, let an in-flight poll finish, then close the
+	// window with sample B — so every counted poll is inside [A, B].
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-time.After(iv):
 	}
+	if ashOn {
+		<-ashDone
+	}
+	hB, hErrB := health.Sample(ctx, t, caps)
 	tB := nowUTC()
 	dt := tB.Sub(tA)
+	if hErr == nil {
+		hErr = hErrB
+	}
+	results[healthName] = &sampled{A: hA, B: hB, Err: hErr, OwnTxns: int64(ash.attempts - ash.failures)}
 
+	// Phase 2: the second sample for the remaining counters — after the window.
 	g2, gctx2 := errgroup.WithContext(ctx)
 	g2.SetLimit(4)
 	for _, c := range registry {
 		c := c
-		if c.Kind() != KindCounter || !c.Available(caps) {
+		if c.Kind() != KindCounter || c.Name() == healthName || !c.Available(caps) {
 			continue
 		}
 		g2.Go(func() error {
@@ -130,11 +159,9 @@ func Run(ctx context.Context, t *conn.Target, opts Options) (*model.Context, err
 		c.Assemble(out, caps, *s, dt, opts)
 	}
 
-	// Fold in the active-session profile once the sampler has finished its window
-	// (it started before phase 1, so this rarely blocks). Query text for per-query
-	// attribution comes from the queries collector's already-scrubbed normals.
+	// Fold in the active-session profile. Query text for per-query attribution
+	// comes from the queries collector's already-scrubbed normals.
 	if ashOn {
-		<-ashDone
 		out.WaitProfile = profileFrom(ash, queryTexts(out))
 	} else {
 		out.WaitProfile = &model.WaitProfile{Available: false, Reason: model.WaitSamplerDisabledReason}

--- a/internal/collect/self_exclusion_test.go
+++ b/internal/collect/self_exclusion_test.go
@@ -1,0 +1,41 @@
+package collect
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/pgrundev/pgbot/internal/conn"
+)
+
+// TestPgStatActivityReadsExcludeSelf pins the self-observation invariant: every
+// read of pg_stat_activity that feeds a user-facing count (connections,
+// idle-in-transaction, xmin holders, the wait profile) must exclude ALL of
+// pgbot's own sessions by application_name — not just the backend running the
+// query. pgbot opens a pool plus a sampler connection, and each collector's
+// `BEGIN READ ONLY … COMMIT` leaves those sessions `idle in transaction`
+// between round trips; a `pid <> pg_backend_pid()` filter hides one of them and
+// counts the rest as the database's activity.
+func TestPgStatActivityReadsExcludeSelf(t *testing.T) {
+	filter := "application_name IS DISTINCT FROM '" + conn.AppName + "'"
+	for name, sql := range map[string]string{
+		"activity.sql":       sqlActivity,
+		"conn_breakdown.sql": sqlConnBreakdown,
+		"horizon.sql":        sqlHorizon,
+		"limits.sql":         sqlLimits,
+		"ash":                ashSQL(conn.Capabilities{VersionNum: 140000}),
+	} {
+		if !strings.Contains(sql, "pg_stat_activity") {
+			t.Errorf("%s: expected a pg_stat_activity read (test is stale)", name)
+			continue
+		}
+		if !strings.Contains(sql, filter) {
+			t.Errorf("%s reads pg_stat_activity without excluding pgbot's own sessions (%q)", name, filter)
+		}
+	}
+	// max_connections limits client backends only; counting every backend_type
+	// (autovacuum, checkpointer, io workers, …) overstates saturation.
+	if !regexp.MustCompile(`(?s)count\(\*\)\s+FROM pg_stat_activity\s+WHERE backend_type = 'client backend'`).MatchString(sqlLimits) {
+		t.Errorf("limits.sql conn_used must count client backends only")
+	}
+}

--- a/internal/collect/settings.go
+++ b/internal/collect/settings.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/pgrundev/pgbot/internal/conn"
 	"github.com/pgrundev/pgbot/internal/model"
 )
@@ -26,7 +27,27 @@ func (settingsCollector) Kind() Kind                       { return KindGauge }
 func (settingsCollector) Available(conn.Capabilities) bool { return true }
 
 func (settingsCollector) Sample(ctx context.Context, t *conn.Target, _ conn.Capabilities) (any, error) {
-	return queryMany[settingRow](ctx, t, sqlSettings)
+	// Report the SERVER's configuration, not this session's. pgbot pins
+	// statement_timeout, lock_timeout, idle_in_transaction_session_timeout,
+	// default_transaction_read_only and stats_fetch_consistency on every
+	// connection; read through those pins they show up as "non-default
+	// parameters" (statement_timeout=15s on a server that has none) and any rule
+	// keyed on them evaluates pgbot instead of the database. UnpinLocal reverts
+	// them for this one transaction; the query below additionally drops
+	// session/client-sourced rows (application_name) from the override set.
+	var rows []settingRow
+	err := t.ReadOnlyTx(ctx, func(tx pgx.Tx) error {
+		if err := conn.UnpinLocal(ctx, tx); err != nil {
+			return err
+		}
+		r, err := tx.Query(ctx, sqlSettings)
+		if err != nil {
+			return err
+		}
+		rows, err = pgx.CollectRows(r, pgx.RowToStructByNameLax[settingRow])
+		return err
+	})
+	return rows, err
 }
 
 func (settingsCollector) Assemble(c *model.Context, _ conn.Capabilities, s sampled, _ time.Duration, _ Options) {

--- a/internal/collect/sql/activity.sql
+++ b/internal/collect/sql/activity.sql
@@ -1,12 +1,13 @@
 -- Point-in-time connection breakdown. Grouped maxes let us derive the global
--- longest transaction / active query by taking max across rows in Go. Excludes
--- our own backend; client backends only.
+-- longest transaction / active query by taking max across rows in Go. Client
+-- backends only, and never pgbot's own sessions (the pool + the wait sampler
+-- sit in `idle in transaction` between BEGIN and each read — see conn.AppName).
 SELECT coalesce(state, 'unknown')          AS state,
        coalesce(wait_event_type, '')       AS wait_event_type,
        count(*)                            AS n,
        coalesce(max(extract(epoch FROM now() - xact_start)), 0)                          AS max_xact_age_s,
        coalesce(max(extract(epoch FROM now() - query_start)) FILTER (WHERE state = 'active'), 0) AS max_active_age_s
 FROM pg_stat_activity
-WHERE pid <> pg_backend_pid()
-  AND backend_type = 'client backend'
+WHERE backend_type = 'client backend'
+  AND application_name IS DISTINCT FROM 'pgbot'
 GROUP BY 1, 2;

--- a/internal/collect/sql/conn_breakdown.sql
+++ b/internal/collect/sql/conn_breakdown.sql
@@ -7,7 +7,7 @@ SELECT coalesce(nullif(application_name, ''), '(none)') AS app_name,
        coalesce(state, 'unknown')                        AS state,
        count(*)                                          AS n
 FROM pg_stat_activity
-WHERE backend_type = 'client backend' AND pid <> pg_backend_pid()
+WHERE backend_type = 'client backend' AND application_name IS DISTINCT FROM 'pgbot'
 GROUP BY 1, 2, 3
 ORDER BY n DESC
 LIMIT 10;

--- a/internal/collect/sql/horizon.sql
+++ b/internal/collect/sql/horizon.sql
@@ -16,7 +16,8 @@ FROM (
                 THEN ', xact ' || round(extract(epoch FROM now() - xact_start))::text || 's'
                 ELSE '' END, ', ') AS detail
   FROM pg_stat_activity
-  WHERE backend_xmin IS NOT NULL AND pid <> pg_backend_pid()
+  WHERE backend_xmin IS NOT NULL
+    AND application_name IS DISTINCT FROM 'pgbot' -- pgbot's own read-only txns hold an xmin too
 
   UNION ALL
   SELECT 'replication_slot', slot_name,

--- a/internal/collect/sql/limits.sql
+++ b/internal/collect/sql/limits.sql
@@ -6,7 +6,13 @@
 -- max_mxid_age tracks multixact-ID wraparound (mxid_age(datminmxid)); multixacts
 -- are consumed by SELECT ... FOR SHARE / FOR UPDATE and FK-check workloads and
 -- exhaust toward the same ~2.1B wall as regular transaction ids.
-SELECT (SELECT count(*) FROM pg_stat_activity)::int               AS conn_used,
+-- conn_used counts what max_connections actually limits: client backends.
+-- Background workers, autovacuum, checkpointer/bgwriter/walwriter and PG18's io
+-- workers appear in pg_stat_activity but draw on other limits; pgbot's own
+-- sessions are transient and excluded (conn.AppName).
+SELECT (SELECT count(*) FROM pg_stat_activity
+         WHERE backend_type = 'client backend'
+           AND application_name IS DISTINCT FROM 'pgbot')::int     AS conn_used,
        current_setting('max_connections')::int                    AS conn_max,
        (SELECT max(age(datfrozenxid)) FROM pg_database)::bigint    AS max_xid_age,
        (SELECT max(mxid_age(datminmxid)) FROM pg_database)::bigint AS max_mxid_age;

--- a/internal/collect/sql/settings.sql
+++ b/internal/collect/sql/settings.sql
@@ -1,10 +1,16 @@
--- Two sets in one scan:
---   'override' — parameters set away from their compiled-in default (human-set knobs).
+-- Two sets in one scan. Runs inside conn.UnpinLocal (settings.go), so setting /
+-- current_setting() reflect the server, database and role configuration rather
+-- than the timeouts and read-only pin pgbot puts on its own session.
+--   'override' — parameters set away from their compiled-in default by a human:
+--                postgresql.conf, ALTER SYSTEM, ALTER DATABASE/ROLE, command line,
+--                environment. Session/client-sourced values are pgbot's own
+--                (application_name) and are not server configuration.
 --   'tuning'   — a fixed whitelist of tuning-relevant parameters, ALWAYS, with their
 --                display values, so the tuning rules can name the current setting.
 SELECT name, setting AS value, 'override' AS kind
 FROM pg_settings
 WHERE setting IS DISTINCT FROM boot_val
+  AND source NOT IN ('session', 'client')
 UNION ALL
 SELECT name, current_setting(name) AS value, 'tuning' AS kind
 FROM pg_settings

--- a/internal/conn/connect.go
+++ b/internal/conn/connect.go
@@ -170,17 +170,19 @@ func probe(ctx context.Context, cc *pgx.ConnConfig) (Capabilities, PoolerInfo, e
 		       (SELECT count(*) FROM pg_settings WHERE name LIKE 'rds.%') > 0,
 		       (SELECT count(*) FROM pg_settings WHERE name LIKE 'cloudsql.%') > 0,
 		       (SELECT count(*) FROM pg_settings WHERE name LIKE 'azure.%') > 0,
-		       pg_is_in_recovery()`
+		       pg_is_in_recovery(),
+		       -- Aurora exposes aurora_version(). Look it up in the catalog rather
+		       -- than calling it: on every other server the call fails, which
+		       -- writes an ERROR to the server log and counts a rollback in
+		       -- pg_stat_database on each pgbot run — the very counter pgbot reports.
+		       (SELECT count(*) FROM pg_proc WHERE proname = 'aurora_version') > 0`
 	err = c.QueryRow(ctx, q, mode...).Scan(&caps.VersionNum, &caps.VersionText, &caps.Database,
 		&caps.StartedAt, &caps.HasStatStatements, &caps.HasHypopg, &caps.HasPgMonitor,
-		&mk.HasRDS, &mk.HasCloudSQL, &mk.HasAzure, &caps.InRecovery)
+		&mk.HasRDS, &mk.HasCloudSQL, &mk.HasAzure, &caps.InRecovery, &mk.IsAurora)
 	if err != nil {
 		return Capabilities{}, pooler, fmt.Errorf("probe capabilities: %w", err)
 	}
 	caps.RecoveryChecked = true // the probe scan succeeded, so InRecovery is trustworthy
-	// Aurora exposes aurora_version(); a failure just means "not Aurora".
-	var av string
-	mk.IsAurora = c.QueryRow(ctx, `SELECT aurora_version()`, mode...).Scan(&av) == nil
 	mk.Host, mk.VersionText = cc.Host, caps.VersionText
 	caps.Provider = detectProvider(mk)
 

--- a/internal/conn/connect.go
+++ b/internal/conn/connect.go
@@ -79,12 +79,20 @@ func (t *Target) Close() {
 	}
 }
 
+// AppName is the application_name every pgbot session carries. Every read of
+// pg_stat_activity filters on it (`application_name IS DISTINCT FROM 'pgbot'`)
+// so pgbot never counts its own pool or wait-sampler connections as the
+// database's activity — connections, idle-in-transaction, xmin holders, ASH.
+// A `pid <> pg_backend_pid()` filter only hides the one backend running that
+// query; the rest of the pool is still visible to it.
+const AppName = "pgbot"
+
 // applySessionSetup pins every physical connection. statement_timeout and
 // lock_timeout are mandatory: pgbot must never become the incident it was
 // invoked to diagnose.
 func applySessionSetup(ctx context.Context, c *pgx.Conn, caps Capabilities) error {
 	stmts := []string{
-		"SET application_name = 'pgbot'",
+		"SET application_name = '" + AppName + "'",
 		"SET statement_timeout = '15s'",
 		"SET lock_timeout = '2s'",
 		"SET idle_in_transaction_session_timeout = '10s'",

--- a/internal/conn/connect.go
+++ b/internal/conn/connect.go
@@ -87,16 +87,42 @@ func (t *Target) Close() {
 // query; the rest of the pool is still visible to it.
 const AppName = "pgbot"
 
+// sessionPins are the GUCs applySessionSetup sets on every pgbot session
+// (application_name is pinned too, but separately: it is pgbot's identity in
+// pg_stat_activity and must never be unpinned, see AppName). Anything that
+// reports server configuration must look past these — pg_settings.setting and
+// current_setting() show THIS session's pinned values, not the database's.
+var sessionPins = []struct{ name, value string }{
+	{"statement_timeout", "'15s'"},
+	{"lock_timeout", "'2s'"},
+	{"idle_in_transaction_session_timeout", "'10s'"},
+	{"default_transaction_read_only", "on"},
+}
+
+// UnpinLocal reverts pgbot's session pins for the current transaction only
+// (SET LOCAL … = DEFAULT restores the value the session would have without our
+// SET — the server / database / role setting). COMMIT re-establishes the pins,
+// so callers get one transaction in which pg_settings and current_setting()
+// describe the database instead of pgbot. Only the settings collector needs it.
+// stats_fetch_consistency (PG15+, also pinned) is deliberately left alone: it is
+// not a tuning parameter, and a SET LOCAL of an unknown GUC would abort the
+// transaction on PG < 15.
+func UnpinLocal(ctx context.Context, tx pgx.Tx) error {
+	for _, p := range sessionPins {
+		if _, err := tx.Exec(ctx, "SET LOCAL "+p.name+" = DEFAULT"); err != nil {
+			return fmt.Errorf("unpin %s: %w", p.name, err)
+		}
+	}
+	return nil
+}
+
 // applySessionSetup pins every physical connection. statement_timeout and
 // lock_timeout are mandatory: pgbot must never become the incident it was
 // invoked to diagnose.
 func applySessionSetup(ctx context.Context, c *pgx.Conn, caps Capabilities) error {
-	stmts := []string{
-		"SET application_name = '" + AppName + "'",
-		"SET statement_timeout = '15s'",
-		"SET lock_timeout = '2s'",
-		"SET idle_in_transaction_session_timeout = '10s'",
-		"SET default_transaction_read_only = on",
+	stmts := []string{"SET application_name = '" + AppName + "'"}
+	for _, p := range sessionPins {
+		stmts = append(stmts, "SET "+p.name+" = "+p.value)
 	}
 	for _, s := range stmts {
 		if _, err := c.Exec(ctx, s); err != nil {

--- a/internal/conn/provider.go
+++ b/internal/conn/provider.go
@@ -27,7 +27,7 @@ type providerMarkers struct {
 	HasRDS      bool // a pg_settings row named rds.*
 	HasCloudSQL bool // cloudsql.*
 	HasAzure    bool // azure.*
-	IsAurora    bool // aurora_version() resolved
+	IsAurora    bool // aurora_version() exists in pg_proc
 }
 
 func detectProvider(m providerMarkers) Provider {

--- a/internal/findings/findings.go
+++ b/internal/findings/findings.go
@@ -875,6 +875,11 @@ func lowCacheHit(c *model.Context, add func(model.Finding)) {
 	if c.Window.ColdWindow() {
 		return
 	}
+	// A ratio over a few hundred blocks is noise, not a signal (the same
+	// reasoning as rollbackMinTxns for high_rollback_ratio).
+	if !c.Health.CacheHitUsable() {
+		return
+	}
 	if *c.Health.CacheHitRatio >= cacheHitWarn {
 		return
 	}

--- a/internal/findings/findings_test.go
+++ b/internal/findings/findings_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func ptr(v float64) *float64 { return &v }
+func i64(v int64) *int64     { return &v }
 
 func has(fs []model.Finding, id string) *model.Finding {
 	for i := range fs {
@@ -20,7 +21,7 @@ func has(fs []model.Finding, id string) *model.Finding {
 func TestCompute_flagsRealIssues(t *testing.T) {
 	c := &model.Context{
 		Window:   model.Window{StatsWindowDays: ptr(120), SampleSeconds: 1},
-		Health:   &model.Health{CacheHitRatio: ptr(0.80), RollbackRatio: ptr(0.15), TPS: ptr(200)}, // enough volume to trust the ratio
+		Health:   &model.Health{CacheHitRatio: ptr(0.80), CacheBlocks: i64(50_000), RollbackRatio: ptr(0.15), TPS: ptr(200)}, // enough volume to trust the ratios
 		Activity: &model.Activity{IdleInTransaction: 2, LongestXactSec: 400},
 		Locks:    &model.Locks{BlockedCount: 1, Chains: []model.BlockingRow{{BlockedPID: 42, WaitSeconds: 30}}},
 		Indexes: &model.Indexes{Unused: []model.IndexStat{
@@ -70,7 +71,7 @@ func TestColdWindow_suppressesCounterFindings_keepsGauges(t *testing.T) {
 	cold := int64(120) // 2 min — below the 900s threshold
 	c := &model.Context{
 		Window: model.Window{WindowAgeSeconds: &cold},
-		Health: &model.Health{CacheHitRatio: ptr(0.50)}, // would fire low_cache_hit on a warm window
+		Health: &model.Health{CacheHitRatio: ptr(0.50), CacheBlocks: i64(50_000)}, // would fire low_cache_hit on a warm window
 		Indexes: &model.Indexes{Unused: []model.IndexStat{
 			{Schema: "public", Table: "orders", Name: "big_idx", Bytes: 50 << 20},
 		}},
@@ -424,5 +425,24 @@ func TestTuning_connectionsOverprovisioned(t *testing.T) {
 	// Small max_connections → not flagged.
 	if has(Compute(&model.Context{Limits: &model.Limits{ConnectionsUsed: 5, ConnectionsMax: 100}}), "connections_overprovisioned") != nil {
 		t.Error("max_connections below the floor must not fire")
+	}
+}
+
+// TestLowCacheHit_needsBlockTraffic: a cache-hit ratio measured over a few
+// hundred blocks is noise (one cold read swings it by tens of points), so the
+// finding must not fire — and must not flip the exit code — until the window
+// carries model.CacheHitMinBlocks of traffic.
+func TestLowCacheHit_needsBlockTraffic(t *testing.T) {
+	thin := &model.Context{Health: &model.Health{CacheHitRatio: ptr(0.40), CacheBlocks: i64(model.CacheHitMinBlocks - 1)}}
+	if has(Compute(thin), "low_cache_hit") != nil {
+		t.Fatalf("low_cache_hit fired on %d blocks of traffic — below the %d floor", model.CacheHitMinBlocks-1, model.CacheHitMinBlocks)
+	}
+	unknown := &model.Context{Health: &model.Health{CacheHitRatio: ptr(0.40)}} // no denominator recorded
+	if has(Compute(unknown), "low_cache_hit") != nil {
+		t.Fatal("low_cache_hit fired without a recorded block count")
+	}
+	enough := &model.Context{Health: &model.Health{CacheHitRatio: ptr(0.40), CacheBlocks: i64(model.CacheHitMinBlocks)}}
+	if has(Compute(enough), "low_cache_hit") == nil {
+		t.Fatal("low_cache_hit must fire at the floor with a 40% ratio")
 	}
 }

--- a/internal/findings/object_test.go
+++ b/internal/findings/object_test.go
@@ -47,7 +47,7 @@ func TestCompute_everyFindingHasStableObject(t *testing.T) {
 	contexts := []*model.Context{
 		{
 			Window:   model.Window{StatsWindowDays: ptr(120), SampleSeconds: 1},
-			Health:   &model.Health{CacheHitRatio: ptr(0.80), RollbackRatio: ptr(0.15), TPS: ptr(200)},
+			Health:   &model.Health{CacheHitRatio: ptr(0.80), CacheBlocks: i64(50_000), RollbackRatio: ptr(0.15), TPS: ptr(200)},
 			Activity: &model.Activity{IdleInTransaction: 2, LongestXactSec: 400},
 			Locks:    &model.Locks{BlockedCount: 1, Chains: []model.BlockingRow{{BlockedPID: 42, WaitSeconds: 30}}},
 			Indexes:  &model.Indexes{Unused: []model.IndexStat{{Schema: "public", Table: "orders", Name: "big_idx", Bytes: 5 << 20}}},

--- a/internal/model/context.go
+++ b/internal/model/context.go
@@ -102,6 +102,11 @@ type WaitProfile struct {
 	ByQuery       []QueryWaits `json:"by_query,omitempty"` // per query_id attribution (PG14+)
 }
 
+// WaitSamplerDisabledReason is the Reason set when the operator turned the
+// sampler off (--ash-hz 0) — the one unavailable state the report need not
+// explain, as opposed to a sampler that ran and failed.
+const WaitSamplerDisabledReason = "sampler disabled (--ash-hz 0)"
+
 // Thin marks a profile too sparse to read as a percentage breakdown.
 func (w *WaitProfile) Thin() bool { return w != nil && w.Samples < WaitMinSamples }
 

--- a/internal/model/context.go
+++ b/internal/model/context.go
@@ -346,7 +346,8 @@ type TableStat struct {
 // Indexes is pg_stat_user_indexes.
 type Indexes struct {
 	Section
-	Total        int              `json:"total"`
+	Total        int              `json:"total"`   // all user indexes
+	Scanned      int              `json:"scanned"` // how many (largest-first) were examined for the unused/largest lists
 	Unused       []IndexStat      `json:"unused,omitempty"`
 	Largest      []IndexStat      `json:"largest,omitempty"`
 	Redundant    []RedundantIndex `json:"redundant,omitempty"`

--- a/internal/model/context.go
+++ b/internal/model/context.go
@@ -219,7 +219,7 @@ type Activity struct {
 	Active              int            `json:"active"`
 	Idle                int            `json:"idle"`
 	IdleInTransaction   int            `json:"idle_in_transaction"`
-	Waiting             int            `json:"waiting"`
+	Waiting             int            `json:"waiting"` // blocked inside the server (any wait_event_type except Client)
 	ByState             map[string]int `json:"by_state"`
 	WaitEvents          map[string]int `json:"wait_events,omitempty"`
 	LongestXactSec      float64        `json:"longest_xact_sec"`

--- a/internal/model/context.go
+++ b/internal/model/context.go
@@ -209,12 +209,28 @@ type Health struct {
 	TPS             *float64 `json:"tps,omitempty"` // commits+rollbacks per second
 	CommitsPerSec   *float64 `json:"commits_per_sec,omitempty"`
 	RollbacksPerSec *float64 `json:"rollbacks_per_sec,omitempty"`
-	RollbackRatio   *float64 `json:"rollback_ratio,omitempty"`  // over the sample window
-	CacheHitRatio   *float64 `json:"cache_hit_ratio,omitempty"` // 0..1 over the sample window
+	RollbackRatio   *float64 `json:"rollback_ratio,omitempty"`       // over the sample window
+	CacheHitRatio   *float64 `json:"cache_hit_ratio,omitempty"`      // 0..1 over the sample window
+	CacheBlocks     *int64   `json:"cache_blocks_sampled,omitempty"` // blks_hit+blks_read within the window — the ratio's denominator
 	DeadlocksPerMin *float64 `json:"deadlocks_per_min,omitempty"`
 	TempBytesPerSec *float64 `json:"temp_bytes_per_sec,omitempty"`
 	TupReturnedPerS *float64 `json:"tuples_returned_per_sec,omitempty"`
 	TupWrittenPerS  *float64 `json:"tuples_written_per_sec,omitempty"` // ins+upd+del
+}
+
+// CacheHitMinBlocks is the block traffic (blks_hit + blks_read, 8 KB each) a
+// sample window must contain before its cache-hit ratio is a signal: 10,000
+// blocks = 80 MB. Below that a few cold reads swing the ratio by tens of
+// points between consecutive runs (measured 58 → 99.7 % on a ~10 tps
+// database whose 30 s ratio was a steady 69 %), flipping the finding, the
+// health score and the exit code on noise.
+const CacheHitMinBlocks = 10_000
+
+// CacheHitUsable reports whether the sampled cache-hit ratio rests on enough
+// block traffic to be graded (see CacheHitMinBlocks). Callers that print or
+// judge the ratio must check this, not just != nil.
+func (h *Health) CacheHitUsable() bool {
+	return h != nil && h.CacheHitRatio != nil && h.CacheBlocks != nil && *h.CacheBlocks >= CacheHitMinBlocks
 }
 
 // Activity is a point-in-time read of pg_stat_activity.

--- a/internal/render/dashboard.go
+++ b/internal/render/dashboard.go
@@ -151,7 +151,7 @@ func buildGood(c *model.Context) []string {
 	}
 	var g []string
 	if h := c.Health; h != nil {
-		if h.CacheHitRatio != nil && !fired["low_cache_hit"] {
+		if h.CacheHitUsable() && !fired["low_cache_hit"] {
 			g = append(g, fmt.Sprintf("cache hit ratio %.1f%%", *h.CacheHitRatio*100))
 		}
 		if h.DeadlocksPerMin != nil && *h.DeadlocksPerMin == 0 {

--- a/internal/render/statusboard.go
+++ b/internal/render/statusboard.go
@@ -106,7 +106,13 @@ func buildBoard(c *model.Context) []boardRow {
 		rows = append(rows, boardRow{"connections", connStatus, connKind, connVal, note})
 		if h.CacheHitRatio != nil {
 			s, k := statusFor("low_cache_hit")
-			rows = append(rows, boardRow{"cache", s, k, pct(*h.CacheHitRatio), ""})
+			note := ""
+			if !h.CacheHitUsable() {
+				// too little block traffic in the window to grade — show the
+				// number, not a verdict (see model.CacheHitMinBlocks)
+				s, k, note = "n/a", kInfo, "thin sample"
+			}
+			rows = append(rows, boardRow{"cache", s, k, pct(*h.CacheHitRatio), note})
 		}
 		if h.TPS != nil {
 			rows = append(rows, boardRow{"throughput", "ok", kOK, humanNum(*h.TPS) + " tps", ""})

--- a/internal/render/terminal.go
+++ b/internal/render/terminal.go
@@ -360,8 +360,15 @@ func renderActivity(b *strings.Builder, st styler, c *model.Context) {
 // indicative, never dressed up as a confident percentage breakdown.
 func renderWaits(b *strings.Builder, st styler, c *model.Context) {
 	w := c.WaitProfile
-	if w == nil || !w.Available {
-		return // disabled (--ash-hz 0) or sampler failed: say nothing here
+	if w == nil || (!w.Available && w.Reason == model.WaitSamplerDisabledReason) {
+		return // operator turned it off: nothing to explain
+	}
+	if !w.Available {
+		// The sampler ran and produced nothing usable. Say so — silently omitting
+		// the section reads as "nothing to report", which is a different claim.
+		fmt.Fprintf(b, "%s  %s\n\n", st.head("WHERE TIME WENT"),
+			st.dim("unavailable — "+w.Reason+" (raise --window, or lower --ash-hz on a high-latency link)"))
+		return
 	}
 	if w.Samples == 0 {
 		fmt.Fprintf(b, "%s  %s\n\n", st.head("WHERE TIME WENT"),

--- a/internal/render/terminal.go
+++ b/internal/render/terminal.go
@@ -633,11 +633,18 @@ func newTab(b *strings.Builder) *tabwriter.Writer {
 }
 
 func truncate(s string, n int) string {
-	s = strings.ReplaceAll(strings.TrimSpace(s), "\n", " ")
-	if len(s) <= n {
+	// Collapse EVERY whitespace run, not just newlines: normalized query text
+	// carries runs of spaces that misalign a tabwriter column. Truncate by rune
+	// so a multi-byte character is never split into invalid UTF-8.
+	s = strings.Join(strings.Fields(s), " ")
+	r := []rune(s)
+	if len(r) <= n {
 		return s
 	}
-	return s[:n-1] + "…"
+	if n < 1 {
+		return "…"
+	}
+	return string(r[:n-1]) + "…"
 }
 
 func humanBytes2(v float64) string { return humanBytes(int64(v)) }

--- a/internal/render/terminal.go
+++ b/internal/render/terminal.go
@@ -265,7 +265,7 @@ func passedChecks(c *model.Context) []string {
 		{"unused indexes", "unused_indexes", c.Indexes != nil && !c.Window.ColdWindow()},
 		{"table bloat", "table_bloat", c.Tables != nil},
 		{"sequential scans", "seq_scan_heavy", c.Tables != nil && !c.Window.ColdWindow()},
-		{"cache hit", "low_cache_hit", c.Health != nil && c.Health.CacheHitRatio != nil && !c.Window.ColdWindow()},
+		{"cache hit", "low_cache_hit", c.Health.CacheHitUsable() && !c.Window.ColdWindow()},
 		{"idle transactions", "idle_in_transaction", c.Activity != nil},
 		{"long transactions", "long_running_transaction", c.Activity != nil},
 		{"rollbacks", "high_rollback_ratio", c.Health != nil && c.Health.RollbackRatio != nil},

--- a/internal/render/terminal.go
+++ b/internal/render/terminal.go
@@ -524,7 +524,13 @@ func renderIndexes(b *strings.Builder, st styler, c *model.Context) {
 	for _, ix := range c.Indexes.Unused {
 		unusedBytes += ix.Bytes
 	}
-	fmt.Fprintf(b, "  %d total · %s unused (%s)\n", c.Indexes.Total, humanNum(float64(len(c.Indexes.Unused))), humanBytes(unusedBytes))
+	scannedNote := ""
+	if c.Indexes.Scanned > 0 && c.Indexes.Scanned < c.Indexes.Total {
+		// The unused/largest lists come from the largest N; smaller unused indexes
+		// below that cut are not counted. Say so rather than imply "unused" is total.
+		scannedNote = fmt.Sprintf(" · largest %d examined", c.Indexes.Scanned)
+	}
+	fmt.Fprintf(b, "  %d total · %s unused in the largest examined (%s)%s\n", c.Indexes.Total, humanNum(float64(len(c.Indexes.Unused))), humanBytes(unusedBytes), scannedNote)
 	fmt.Fprintln(b)
 }
 

--- a/internal/render/terminal_test.go
+++ b/internal/render/terminal_test.go
@@ -13,12 +13,13 @@ import (
 func sampleContext() *model.Context {
 	tps := 1200.0
 	hit := 0.994
+	blocks := int64(250_000) // enough block traffic for the ratio to be graded
 	return &model.Context{
 		SchemaVersion: model.SchemaVersion,
 		CollectedAt:   time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC),
 		Server:        model.ServerInfo{VersionNum: 170010, Database: "app", HasPgMonitor: true},
 		Window:        model.Window{SampleSeconds: 1.0},
-		Health:        &model.Health{Section: model.Section{Exactness: model.ExactnessSampled}, Connections: 24, TPS: &tps, CacheHitRatio: &hit},
+		Health:        &model.Health{Section: model.Section{Exactness: model.ExactnessSampled}, Connections: 24, TPS: &tps, CacheHitRatio: &hit, CacheBlocks: &blocks},
 		Activity:      &model.Activity{Section: model.Section{Exactness: model.ExactnessScraped}, Total: 24, Active: 6},
 		Findings: []model.Finding{
 			{ID: "unused_indexes", Severity: model.SeverityWarn, Title: "1 unused index",


### PR DESCRIPTION
## Summary

pgbot's read path counts, times and measures **its own footprint** as if it were the database's, in several places. Its guiding principle — *"pgbot must never become the incident it was invoked to diagnose"* (`connect.go`) — holds for locks and timeouts, but not yet for the statistics it reports. This PR makes pgbot subtract itself from what it observes, plus a few adjacent reporting fixes and the build fix for `main`.

Every change was measured against a real PostgreSQL 18.4 (24 GB, ~10 tps, `pg_stat_statements` full) over an ~80 ms link — the remote case (`inspect` from a laptop/CI to RDS/Neon/Supabase) is where these bugs bite hardest. Old = released **v0.1.6**, new = this branch, run seconds apart:

| metric | v0.1.6 | this PR | server truth (psql) |
|---|---|---|---|
| `idle_in_transaction` | 2 | **0** | 0 |
| `connections` used | 18 | **8** | client backends only (v0.1.6 counted 9 aux procs) |
| rollback ratio | 5.0% | **0** | ~0 (230 in 12 days) |
| `temp_bytes_per_sec` | 423 KB/s | **0** | 0 |
| settings "non-default" | 44 | **37** | 24 human-set knobs |
| `statement_timeout` reported | `15s` | **`0`** | `0` (the real server value) |
| index count | 200 | **398** | 398 |
| wait profile | *failed (all polls errored)* | **works** | — |
| **side effects per run** | **+9 rollbacks, +1 temp file** | **+0, +0** | — |

## The build fix (first commit)

`main` @ 733e390 does not compile — `cmd/pgbot/{explain,gather,inspect}.go` still call `computeFindings(c, f.config, f.ignore)` after the B2-4 signature became `computeFindings(c, f)`. First commit fixes the three call sites; CI for that commit is red on `go build`.

## The self-observation bugs

pgbot opens a connection pool and a wait-sampler connection. Every read of `pg_stat_activity` filtered only `pid <> pg_backend_pid()`, which hides the *one* backend running the query and leaves the rest of the pool visible. Between each collector's `BEGIN READ ONLY` and its read, those sessions sit in `idle in transaction` — so pgbot reported **its own pool** as the database's idle-in-transaction sessions (measured: 13 pgbot backends during one `inspect`, 37 of 172 `pg_stat_activity` observations idle-in-txn; the app had 0). The fix pins `application_name = 'pgbot'` (already set) as the identity every read excludes.

- **Sessions** (`activity.sql`, `conn_breakdown.sql`, `horizon.sql`, `ash`): exclude `application_name IS DISTINCT FROM 'pgbot'`. A guard test pins the invariant for every `pg_stat_activity` read.
- **Connections** (`limits.sql`): `conn_used` now counts `backend_type = 'client backend'` only. `max_connections` doesn't cover autovacuum, the checkpointer/bgwriter/walwriter, bgworkers or PG18's io workers, yet `count(*) FROM pg_stat_activity` included them (30 vs 21 here) — a low `max_connections` tripped `connection_saturation` on background load alone.
- **`Waiting`** no longer counts `wait_event_type = 'Client'` (an idle backend on `ClientRead` is waiting for the *application*, not blocked in the server); the `wait_events` breakdown still lists it.
- **Settings** (`settings.go`, `settings.sql`): pgbot's session pins (`statement_timeout=15s`, `lock_timeout`, `idle_in_transaction_session_timeout`, `default_transaction_read_only`, `stats_fetch_consistency`) showed up as "non-default parameters", and every rule keyed on a pinned GUC evaluated pgbot, not the server. **This made the new `statement_timeout_unset` rule dead** — `settingParam("statement_timeout")` was always `"15s"` (verified against a server whose real value is `0`; the finding now fires). The settings collector reads inside a new `conn.UnpinLocal(tx)` (transaction-scoped `SET LOCAL … = DEFAULT`), and the query drops session/client-sourced rows.
- **TPS / rollback ratio** (`runner.go`, `health.go`): the sample window is `[health sample A, health sample B]`. Health was collected in the same fan-out as everything else, so sample A preceded phase 1's own statements (each `SET` on a fresh pooled connection is a committed implicit transaction) and every wait-sampler poll landed inside the window and was counted as the database's throughput — the whole figure on a quiet server (36 tps / 2.3% rollback while the app did ~0). `Run` now brackets the window with health explicitly; the sampler's successful polls are subtracted (`sampled.OwnTxns`).
- **Aurora probe** (`connect.go`): `SELECT aurora_version()` fails on every non-Aurora server — one ERROR line in the server log and one `xact_rollback` per run, on the counter pgbot reports. Detect it from `pg_proc` instead, folded into the existing probe query.
- **Temp files** (`queries.go`): `pg_stat_statements` is a set-returning function; a scan materializes every tracked statement (up to 4 KB text each) with `queries.sql`'s `sum() OVER ()`. At the default `work_mem=4MB` and ~5k statements that is a ~5 MB temp file *per run* — read back inside the window as `temp_bytes_per_sec ≈ 1 MiB/s`, exactly the `tune` rule's threshold, so "raise work_mem" fired on itself. Now `SET LOCAL work_mem = '64MB'` for that read and `pg_stat_statements(false)` for the count.

## Other reporting fixes

- **Wait sampler couldn't run remotely** (`ash.go`, `runner.go`, `terminal.go`): each poll got `1/hz` = 100 ms at the default 10 Hz, but a poll was 3 round trips, so at ~80 ms RTT **every poll timed out**, each timeout tore down a pool connection (reconnect storm, 13 backends/run) and rolled back, and `renderWaits` returned silently — the terminal showed no "WHERE TIME WENT" section at all. Fixed per-poll budget (1 s, decoupled from the tick), one round trip per poll (the session is already read-only), and the report now says when the profile is unavailable and why.
- **`low_cache_hit` volume guard** (`findings.go`): the ratio over a 1–5 s window swung 58 → 99.7% on this ~10 tps server between runs, flipping the WARNING, the health score, the exit code and even the "GOOD cache hit ratio 99.7%" line (steady state is 68.8%). It now requires ≥ `CacheHitMinBlocks` (80 MB) of block traffic to be graded — mirroring `rollbackMinTxns`. (A follow-up could grade the median of recent baseline samples for the bursty-workload case; noted in the commit.)
- **Index count** (`indexes.go`): `indexes.sql` is `LIMIT 200`, but the report printed `Total = len(rows)` → "200 total" on a 398-index database. `Total` is now a real `count(*)`; the render says "398 total … largest 200 examined".
- **`vacuum` "due?"** (`vacuum.go`): graded against hard-coded `50 + 20%` regardless of the cluster GUCs or per-table reloptions (both already collected), and marked `autovacuum_enabled=false` tables "due". Now honors `autovacuum_vacuum_threshold`/`_scale_factor`, per-table overrides, and disabled autovacuum.
- **Query text rendering** (`queries.go`, `terminal.go`): normalized text is multi-line with runs of spaces; byte-slicing after replacing only `\n` broke `tabwriter` rows and could split a multi-byte rune. Both truncators now collapse whitespace (`strings.Fields`) and truncate by rune.

## Testing

- `go vet ./...` clean; `go test ./...` green; cross-builds for linux/darwin × amd64/arm64.
- New unit tests: `self_exclusion_test.go` (every `pg_stat_activity` read excludes pgbot), `low_cache_hit` volume floor, `expectAutovacuum` with GUCs/reloptions/disabled, rune-safe/whitespace truncation.
- Integration tests pass against a live DB, including new self-observation assertions in `TestIntegration_fullPipeline` (idle-in-txn = 0 on an idle DB; no session pin leaks into `overrides`/`params`). The one exception is that test's pre-existing `< 5s` wall-clock assertion, which fails identically on **unmodified upstream** over the same ~80 ms link (local-Postgres CI passes both) — this PR adds ~0.5 s of window-bracketing latency there and trims it back with the single-round-trip health read.

No behavior change to the read-only guarantee: every path is still read-only, and `application_name` is never unpinned (it is how the other collectors exclude pgbot). Happy to split this into smaller PRs if you'd prefer to take them piecemeal.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

