### PR TITLE
Index/code correlation + guaranteed destructive-action guards (schema 1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ separately by `model.SchemaVersion` (currently 1.1.0).
   USING INDEX` index shows zero scans on the primary but dropping it breaks logical
   replication and UPDATE/DELETE row identity — now excluded alongside PK / unique /
   exclusion / FK-backing indexes.
+- **Destructive-action guards are now structured and guaranteed (`finding.safety`).**
+  Every finding whose remediation involves a destructive or irreversible action
+  (DROP INDEX, VACUUM FULL, REINDEX, DROP REPLICATION SLOT, a table rewrite) now
+  carries machine-actionable guards — `{id, kind: prohibition|precondition, action,
+  text, verify}` — instead of leaving the warning to free-form prose a summarizing
+  model could drop. They are emitted deterministically in code and guaranteed in
+  `--json`, SARIF, the MCP payloads, and both terminal views. Two guards that
+  previously existed **only** in docs pages are now on the finding itself: the
+  wraparound "don't VACUUM FULL / don't consume XIDs" guard, and the "don't drop a
+  replication slot a live standby still depends on" guard (whose remediation no
+  longer nudges toward the drop before the check). `pgbot ask` / `explain` reassert
+  these guards from code, after the model's text, so the model cannot omit them. A
+  build-failing regression test fails CI if a destructive remediation ships without
+  a guard.
 
 ### Changed
 - `model.IndexStat` gains `columns`, `method`, `unique`, and `primary` (additive).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,21 @@ separately by `model.SchemaVersion` (currently 1.1.0).
   longer nudges toward the drop before the check). `pgbot ask` / `explain` reassert
   these guards from code, after the model's text, so the model cannot omit them. A
   build-failing regression test fails CI if a destructive remediation ships without
-  a guard.
+  a guard. The guards are also carried by SARIF, JUnit (`<failure>` text), and a
+  Prometheus `destructive="true"` label; a test AST-scans the render package and
+  fails the build if a new output surface ships without carrying them. **For a
+  database with a destructive finding, the default and `--full` terminal views now
+  add a `⚠` guard line — clean databases are byte-identical.**
+- **Verdict strengthening is bounded (index/code correlation).** A stored code
+  search plus a growing window is the one place confidence could rise on its own,
+  so: a verdict older than the current stats window is marked **stale** (`stale`,
+  `age_days`), its age is stated in output ("code check is 47 days old — the
+  repository may have changed since"), and a stale verdict never strengthens. The
+  strengthened wording reads as corroboration, never authorization (the phrases
+  "safe to drop" / "confirmed unused" are never generated), and the `precondition`
+  guard persists through any verdict. An `inconclusive` index is never promoted by
+  any verdict at any window length. The `if_not_found` caveat now always names
+  monthly/quarterly/annual jobs a long window still can't see.
 
 ### Changed
 - `model.IndexStat` gains `columns`, `method`, `unique`, and `primary` (additive).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ separately by `model.SchemaVersion` (currently 1.1.0).
 
 ## [Unreleased]
 
+### Added
+- **Index/code correlation (`pgbot indexes --correlate`, MCP `index_code_correlation`).**
+  pgbot grades every unused / redundant / invalid index by how the drop can be
+  *proven*, and hands an agent exactly what to search for — without ever reading
+  your repository:
+  - `catalog_proven` — invalid or redundant/duplicate; provable from the catalog
+    alone, no code check, no stats-window caveat.
+  - `needs_code_check` — a zero-scan plain btree over bare columns. pgbot emits the
+    identifiers to grep in every case convention (camelCase, snake_case,
+    PascalCase, CONSTANT_CASE) plus the load-bearing instruction: search *filter*
+    positions only (WHERE / JOIN / ORDER BY / GROUP BY / ORM filters), never SELECT
+    lists — and how to read a hit vs. a miss.
+  - `inconclusive` — GIN/GiST/BRIN, expression, partial, or a cold window. These
+    can serve a query shape that simply hasn't run, so they keep "do not DROP INDEX
+    on this evidence" and are **never** promoted to actionable by an empty code
+    search. pgbot never reads the repo and never drops anything.
+- **Verdict write-back (MCP `record_index_verdict`).** An agent records what its
+  repo search found (`found_in_code` / `not_found_in_code` / `inconclusive`),
+  stored locally per database. On a later run the same still-unused index carries
+  the prior verdict forward and notes when the zero-scan window has since grown —
+  a one-off grep becomes compounding evidence. New `index_verdicts` store table
+  only; no existing table changes.
+- **Replica-identity indexes are never reported as unused.** A `REPLICA IDENTITY
+  USING INDEX` index shows zero scans on the primary but dropping it breaks logical
+  replication and UPDATE/DELETE row identity — now excluded alongside PK / unique /
+  exclusion / FK-backing indexes.
+
+### Changed
+- `model.IndexStat` gains `columns`, `method`, `unique`, and `primary` (additive).
+  JSON contract `SchemaVersion` → **1.2.0**; a 1.1.0 consumer still parses 1.2.0
+  output unchanged.
+
 ## [0.3.3] - 2026-08-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ pgbot baselines prune <fingerprint> # delete a database's snapshots
 pgbot baselines export <fingerprint># dump stored snapshots as JSON
 
 pgbot indexes <connection-string>   # zero-scan indexes + what NOT to drop
+  --correlate            grade each index (catalog_proven/needs_code_check/inconclusive) + what to grep in code
 pgbot queries <connection-string>   # top pg_stat_statements by total time (--by-calls to re-rank)
 pgbot tables  <connection-string>   # largest tables + row counts + seq-vs-index scan pattern
 pgbot vacuum <connection-string>    # autovacuum health per table — dead tuples + whether it's due
@@ -401,6 +402,13 @@ on stdio, so an AI agent can call pgbot as a read-only tool. It exposes
 - `inspect` — full findings as JSON
 - `unused_indexes`, `top_queries`, `vacuum_health` — the CLI's focused views
 - `suggest_indexes` — planner-validated index recommendations (hypopg)
+- `index_code_correlation` — grades each unused/redundant/invalid index
+  (`catalog_proven` / `needs_code_check` / `inconclusive`) and, for the actionable
+  ones, the exact identifiers to grep (all case conventions) with the instruction
+  to search *filters* (WHERE/JOIN/ORDER BY), never SELECT lists. pgbot never reads
+  your repo; it says what to search for. Also `pgbot indexes --correlate [--json]`.
+- `record_index_verdict` — store what the repo search found, so a later run over a
+  longer window carries strengthening evidence (no DB connection needed)
 - `explain_plan` — the planner's plan for a SELECT (plain EXPLAIN, never executed)
 - `schema_of` — a table's columns/indexes/constraints + row estimate, **no data**
 - `compare_to_baseline` — the `diff`, with its interval-honesty and reset caveats

--- a/cmd/pgbot/ask.go
+++ b/cmd/pgbot/ask.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pgrundev/pgbot/internal/ai"
+	"github.com/pgrundev/pgbot/internal/model"
 	"github.com/pgrundev/pgbot/internal/render"
 	"github.com/spf13/cobra"
 )
@@ -67,7 +68,47 @@ func runAsk(cmd *cobra.Command, question, url string, f inspectFlags, yes bool) 
 
 	answer, aiErr := ai.Ask(ctx, client, c, question)
 	printAnswer(useColor(false), client.ModelName(), answer, aiErr)
+	if aiErr == nil {
+		// `ask` prints only the model's prose, so a destructive-action guard that
+		// the model may have reworded away must be reasserted here, verbatim from
+		// the deterministic findings — never at the model's discretion.
+		printSafetyFooter(useColor(false), c)
+	}
 	return nil
+}
+
+// printSafetyFooter reasserts, from code, every destructive-action guard attached
+// to a non-suppressed finding — the warnings a summarizing model must not lose. It
+// is rendered outside the model's output so the model has no way to omit or reword
+// it. Deduped by guard ID.
+func printSafetyFooter(color bool, c *model.Context) {
+	var lines []string
+	seen := map[string]bool{}
+	for _, f := range c.Findings {
+		if f.Suppressed || f.Safety == nil {
+			continue
+		}
+		for _, g := range f.Safety.BlockingCaveats {
+			if seen[g.ID] {
+				continue
+			}
+			seen[g.ID] = true
+			line := "[" + g.Action + "] " + g.Text
+			if g.Verify != nil {
+				line += " Only after: " + *g.Verify
+			}
+			lines = append(lines, line)
+		}
+	}
+	if len(lines) == 0 {
+		return
+	}
+	st := render.NewStyler(color)
+	fmt.Println()
+	fmt.Println(st.Warn("⚠ Safety (from pgbot, not the model) — a destructive action is in scope for this database:"))
+	for _, l := range lines {
+		fmt.Println(st.Dim("  • " + l))
+	}
 }
 
 // printAnswer renders `ask` cleanly: the answer itself, then one dim line making

--- a/cmd/pgbot/correlate.go
+++ b/cmd/pgbot/correlate.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/pgrundev/pgbot/internal/correlate"
+	"github.com/pgrundev/pgbot/internal/model"
+	"github.com/pgrundev/pgbot/internal/render"
+	"github.com/pgrundev/pgbot/internal/store"
+)
+
+// loadIndexVerdicts reads prior code-search verdicts for a database from the
+// local store. Best-effort: a missing/unreadable store just means no history —
+// correlation still works, it simply can't say "evidence has strengthened".
+func loadIndexVerdicts(storePath, fingerprint string) map[string]correlate.PriorVerdict {
+	if fingerprint == "" {
+		return nil
+	}
+	st, err := store.Open(storePath)
+	if err != nil {
+		return nil
+	}
+	defer st.Close()
+	raw, err := st.LoadIndexVerdicts(fingerprint)
+	if err != nil {
+		return nil
+	}
+	out := make(map[string]correlate.PriorVerdict, len(raw))
+	for k, v := range raw {
+		out[k] = correlate.PriorVerdict{
+			Verdict: v.Verdict, Source: v.Source, RepoRef: v.RepoRef,
+			CheckedAt: v.CheckedAt, StatsWindowDays: v.StatsWindowDays,
+		}
+	}
+	return out
+}
+
+// buildCorrelation assembles the index/code correlation report, folding in any
+// prior verdicts from the store.
+func buildCorrelation(c *model.Context, storePath string) correlate.Report {
+	return correlate.Build(c, loadIndexVerdicts(storePath, c.Fingerprint))
+}
+
+// renderCorrelation prints the report grouped by confidence, highest first. The
+// grouping is the point: catalog_proven is safe, needs_code_check is a task for
+// the agent, inconclusive must not be dropped on this evidence.
+func renderCorrelation(w io.Writer, st render.Styler, rep correlate.Report) {
+	head := "Index / code correlation"
+	if rep.StatsWindowDays != nil {
+		head += fmt.Sprintf(" — %.0fd window", *rep.StatsWindowDays)
+	}
+	fmt.Fprintf(w, "%s\n\n", st.Head(head))
+
+	if rep.ColdWindow {
+		fmt.Fprintln(w, st.AI("⚠ cold statistics window — zero-scan counts just started; nothing is actionable yet."))
+	}
+	if rep.ReplicationActive {
+		fmt.Fprintln(w, st.AI("⚠ replication active — scan counts are per-node; a replica may use an index that looks unused here."))
+	}
+	if rep.ColdWindow || rep.ReplicationActive {
+		fmt.Fprintln(w)
+	}
+
+	groups := []struct {
+		conf  correlate.Confidence
+		label string
+	}{
+		{correlate.CatalogProven, st.Good("CATALOG-PROVEN") + " — provable from the catalog alone, no code check"},
+		{correlate.NeedsCodeCheck, "NEEDS CODE CHECK — grep the terms, then decide"},
+		{correlate.Inconclusive, st.Dim("INCONCLUSIVE — do NOT drop on this evidence")},
+	}
+	any := false
+	for _, g := range groups {
+		var rows []correlate.IndexReport
+		for _, ix := range rep.Indexes {
+			if ix.Confidence == g.conf {
+				rows = append(rows, ix)
+			}
+		}
+		if len(rows) == 0 {
+			continue
+		}
+		any = true
+		fmt.Fprintf(w, "%s (%d)\n", g.label, len(rows))
+		for _, ix := range rows {
+			loc := ix.Schema + "." + ix.Table
+			fmt.Fprintf(w, "  ● %s  %s\n", ix.Index, st.Dim(fmt.Sprintf("(%s · %s)", loc, render.HumanBytes(ix.SizeBytes))))
+			fmt.Fprintf(w, "    %s\n", ix.Reason)
+			if len(ix.SearchTerms) > 0 {
+				fmt.Fprintf(w, "    %s %v\n", st.Dim("search:"), ix.SearchTerms)
+				fmt.Fprintf(w, "    %s\n", st.Dim("in filters only (WHERE/JOIN/ORDER BY/GROUP BY), never SELECT lists"))
+			}
+			if ix.PriorVerdict != nil {
+				fmt.Fprintf(w, "    %s %s\n", st.Dim("prior:"), ix.Note)
+			}
+		}
+		fmt.Fprintln(w)
+	}
+	if !any {
+		fmt.Fprintln(w, st.Good("✓ no unused, redundant, or invalid indexes to correlate in this window"))
+	}
+}

--- a/cmd/pgbot/correlate.go
+++ b/cmd/pgbot/correlate.go
@@ -91,8 +91,23 @@ func renderCorrelation(w io.Writer, st render.Styler, rep correlate.Report) {
 				fmt.Fprintf(w, "    %s %v\n", st.Dim("search:"), ix.SearchTerms)
 				fmt.Fprintf(w, "    %s\n", st.Dim("in filters only (WHERE/JOIN/ORDER BY/GROUP BY), never SELECT lists"))
 			}
-			if ix.PriorVerdict != nil {
-				fmt.Fprintf(w, "    %s %s\n", st.Dim("prior:"), ix.Note)
+			if ix.IfNotFound != "" {
+				fmt.Fprintf(w, "    %s %s\n", st.Dim("if absent:"), st.Dim(ix.IfNotFound))
+			}
+			if v := ix.PriorVerdict; v != nil {
+				stale := ""
+				if v.Stale {
+					stale = st.AI(" — STALE")
+				}
+				ref := ""
+				if v.RepoRef != "" {
+					ref = ", commit " + v.RepoRef
+				}
+				fmt.Fprintf(w, "    %s %s (%dd old%s)%s\n", st.Dim("prior code search:"), v.Verdict, v.AgeDays, ref, stale)
+				// The corroboration/staleness sentence only rides a needs_code_check note.
+				if ix.Note != "" && ix.Confidence == correlate.NeedsCodeCheck {
+					fmt.Fprintf(w, "    %s\n", st.Dim(ix.Note))
+				}
 			}
 		}
 		fmt.Fprintln(w)

--- a/cmd/pgbot/explain.go
+++ b/cmd/pgbot/explain.go
@@ -128,6 +128,11 @@ func runExplain(cmd *cobra.Command, args []string, f inspectFlags, yes bool) err
 	// unavailable and exit on the findings' code.
 	explanation, aiErr := ai.Explain(ctx, client, c)
 	printAISection(color, client.ModelName(), explanation, aiErr)
+	// The destructive-action guards, reasserted by code AFTER the model text — so a
+	// reworded or truncated explanation can never be the thing that drops them.
+	if aiErr == nil {
+		printSafetyFooter(color, c)
+	}
 
 	os.Exit(exitCode(c.Findings, f.failOn))
 	return nil

--- a/cmd/pgbot/indexes.go
+++ b/cmd/pgbot/indexes.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -13,14 +14,17 @@ import (
 
 // newIndexesCmd — `pgbot indexes`. A focused view of zero-scan indexes: what
 // they cost and, crucially, the replication caveat before anyone drops one.
+// With --correlate it emits the index/code correlation payload (confidence
+// levels + what to grep) instead — pgbot never reads the repo; the agent does.
 func newIndexesCmd() *cobra.Command {
 	var f inspectFlags
+	var doCorrelate bool
 	cmd := &cobra.Command{
 		Use:   "indexes <connection-string>",
 		Short: "List indexes with zero scans in the observed window (and what NOT to drop)",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runIndexes(cmd, args, f)
+			return runIndexes(cmd, args, f, doCorrelate)
 		},
 	}
 	fl := cmd.Flags()
@@ -28,10 +32,12 @@ func newIndexesCmd() *cobra.Command {
 	fl.BoolVar(&f.noStore, "no-store", true, "skip the local baseline store (default for a quick listing)")
 	fl.StringVar(&f.storePath, "store", "", "baseline DB path (default: XDG state dir)")
 	fl.DurationVar(&f.timeout, "timeout", 30*time.Second, "total wall-clock budget for the run (raise it for slow or remote databases)")
+	fl.BoolVar(&doCorrelate, "correlate", false, "emit the index/code correlation payload: confidence levels + identifiers to search for in code (pgbot never reads the repo)")
+	fl.BoolVar(&f.json, "json", false, "JSON output (implies --correlate; the machine-readable correlation payload)")
 	return cmd
 }
 
-func runIndexes(cmd *cobra.Command, args []string, f inspectFlags) error {
+func runIndexes(cmd *cobra.Command, args []string, f inspectFlags, doCorrelate bool) error {
 	connString := firstNonEmpty(argAt(args, 0), os.Getenv("DATABASE_URL"), os.Getenv("PGBOT_DATABASE_URL"))
 	if connString == "" {
 		return fmt.Errorf("no connection string (pass one or set $DATABASE_URL)")
@@ -48,6 +54,23 @@ func runIndexes(cmd *cobra.Command, args []string, f inspectFlags) error {
 	}
 
 	st := render.NewStyler(useColor(f.noColor))
+
+	// --correlate (or --json, which implies it) switches to the correlation
+	// payload. The default listing below is unchanged.
+	if doCorrelate || f.json {
+		rep := buildCorrelation(c, f.storePath)
+		if f.json {
+			b, err := json.MarshalIndent(rep, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(b))
+			return nil
+		}
+		renderCorrelation(os.Stdout, st, rep)
+		return nil
+	}
+
 	if c.Indexes == nil || len(c.Indexes.Unused) == 0 {
 		fmt.Println(st.Good("✓ no zero-scan indexes in this window"))
 		return nil

--- a/cmd/pgbot/mcp.go
+++ b/cmd/pgbot/mcp.go
@@ -304,6 +304,14 @@ func unusedIndexesTool(ctx context.Context, args json.RawMessage) (string, error
 	if c.Indexes != nil {
 		out["unused"] = c.Indexes.Unused
 	}
+	// Carry the deterministic drop guard structurally — dropping an index is
+	// destructive and the per-node/replica warning must not be lost to a summarizer.
+	for _, f := range c.Findings {
+		if f.ID == "unused_indexes" && f.Safety != nil {
+			out["safety"] = f.Safety
+			break
+		}
+	}
 	b, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		return "", err

--- a/cmd/pgbot/mcp.go
+++ b/cmd/pgbot/mcp.go
@@ -152,6 +152,38 @@ func pgbotTools() []mcp.Tool {
 			},
 			Handler: explainFindingTool,
 		},
+		{
+			Name: "index_code_correlation",
+			Description: "For each unused / redundant / invalid index, return a confidence level " +
+				"(catalog_proven = safe to drop from the catalog alone; needs_code_check = actionable only with a " +
+				"code search; inconclusive = do NOT drop on this evidence) and, for needs_code_check, the exact " +
+				"identifiers to grep — camelCase, snake_case, PascalCase, CONSTANT_CASE — plus how to read the " +
+				"result: search FILTER positions only (WHERE/JOIN/ORDER BY/GROUP BY), never SELECT lists. pgbot " +
+				"never reads your repository; it tells you what to search for and how to interpret it. Also returns " +
+				"a fingerprint to pass back to record_index_verdict. Read-only.",
+			InputSchema: dsnSchema,
+			Handler:     indexCorrelationTool,
+		},
+		{
+			Name: "record_index_verdict",
+			Description: "Record an agent's code-search verdict for one index (found_in_code | not_found_in_code | " +
+				"inconclusive), keyed by the fingerprint from index_code_correlation. Stored locally so a later run " +
+				"over a longer stats window carries strengthening evidence instead of starting over. No database " +
+				"connection needed — this only writes pgbot's local store.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"fingerprint":       map[string]any{"type": "string", "description": "Database fingerprint from index_code_correlation."},
+					"index":             map[string]any{"type": "string", "description": "Schema-qualified index, e.g. public.Job_externalIdNormalized_idx."},
+					"verdict":           map[string]any{"type": "string", "description": "found_in_code | not_found_in_code | inconclusive."},
+					"source":            map[string]any{"type": "string", "description": "Optional, e.g. agent_repo_search."},
+					"repo_ref":          map[string]any{"type": "string", "description": "Optional commit sha the search ran against."},
+					"stats_window_days": map[string]any{"type": "number", "description": "Optional: the stats_window_days you saw, so a later run can show the window has grown."},
+				},
+				"required": []string{"fingerprint", "index", "verdict"},
+			},
+			Handler: recordIndexVerdictTool,
+		},
 	}
 }
 

--- a/cmd/pgbot/mcp_tools.go
+++ b/cmd/pgbot/mcp_tools.go
@@ -16,8 +16,10 @@ import (
 
 // B8 MCP tools. Every one either produces no findings (explain_plan, schema_of,
 // explain_finding) or reuses a path that already honors B2 suppression
-// (compare_to_baseline over stored snapshots); responses carry exactness/caveat
-// labels so an agent can't strip the "estimate, not measurement" qualifier.
+// (compare_to_baseline over stored snapshots). Responses carry exactness/caveat
+// labels in the PAYLOAD: the guarantee is that the "estimate, not measurement"
+// qualifier is present in the response, not that the consuming model preserves it
+// — a third-party client can still reword or drop it on its side.
 
 // explainPlanTool runs a PLAIN EXPLAIN (the plan-only form) of an agent-supplied query
 // through the same guard as the advisor: SanitizeSelect (single plain SELECT, no

--- a/cmd/pgbot/mcp_tools.go
+++ b/cmd/pgbot/mcp_tools.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pgrundev/pgbot/docs"
 	"github.com/pgrundev/pgbot/internal/advisor"
 	"github.com/pgrundev/pgbot/internal/conn"
+	"github.com/pgrundev/pgbot/internal/store"
 )
 
 // B8 MCP tools. Every one either produces no findings (explain_plan, schema_of,
@@ -163,6 +164,62 @@ func explainFindingTool(_ context.Context, args json.RawMessage) (string, error)
 		return "", fmt.Errorf("no catalogue page for %q — pass a finding id from a report", a.ID)
 	}
 	return stripFrontMatter(string(data)), nil
+}
+
+// indexCorrelationTool runs a read-only collection and returns the index/code
+// correlation payload — confidence levels plus, for the actionable ones, the
+// identifiers to grep and how to interpret the result. pgbot never reads the repo.
+func indexCorrelationTool(ctx context.Context, args json.RawMessage) (string, error) {
+	dsn, err := dsnFromArgs(args)
+	if err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	c, _, err := gather(ctx, dsn, inspectFlags{interval: time.Second, ashHz: 0, noStore: true})
+	if err != nil {
+		return "", err
+	}
+	// Default store path for verdict read-back; a missing store just means no history.
+	return marshal(buildCorrelation(c, ""))
+}
+
+// recordIndexVerdictTool persists an agent's code-search verdict for one index.
+// It writes only the local store — no database connection — so the agent can
+// record what its repo grep found after index_code_correlation told it what to look for.
+func recordIndexVerdictTool(_ context.Context, args json.RawMessage) (string, error) {
+	var a struct {
+		Fingerprint     string   `json:"fingerprint"`
+		Index           string   `json:"index"`
+		Verdict         string   `json:"verdict"`
+		Source          string   `json:"source"`
+		RepoRef         string   `json:"repo_ref"`
+		StatsWindowDays *float64 `json:"stats_window_days"`
+	}
+	_ = json.Unmarshal(args, &a)
+	if a.Fingerprint == "" || a.Index == "" || a.Verdict == "" {
+		return "", fmt.Errorf("fingerprint, index, and verdict are required")
+	}
+	switch a.Verdict {
+	case "found_in_code", "not_found_in_code", "inconclusive":
+	default:
+		return "", fmt.Errorf("verdict must be one of: found_in_code, not_found_in_code, inconclusive")
+	}
+	st, err := store.Open("")
+	if err != nil {
+		return "", err
+	}
+	defer st.Close()
+	if err := st.SaveIndexVerdict(a.Fingerprint, store.IndexVerdict{
+		IndexID: a.Index, Verdict: a.Verdict, Source: a.Source, RepoRef: a.RepoRef,
+		CheckedAt: time.Now(), StatsWindowDays: a.StatsWindowDays,
+	}); err != nil {
+		return "", fmt.Errorf("record verdict: %w", err)
+	}
+	return marshal(map[string]any{
+		"recorded": true, "fingerprint": a.Fingerprint, "index": a.Index, "verdict": a.Verdict,
+		"note": "stored locally; a later index_code_correlation over a longer window will carry this forward as strengthening evidence.",
+	})
 }
 
 // scanRows runs a query with one bind arg and returns its rows as []map, column

--- a/internal/collect/correlate_integration_test.go
+++ b/internal/collect/correlate_integration_test.go
@@ -1,0 +1,129 @@
+package collect_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/pgrundev/pgbot/internal/collect"
+	"github.com/pgrundev/pgbot/internal/conn"
+	"github.com/pgrundev/pgbot/internal/correlate"
+	"github.com/pgrundev/pgbot/internal/model"
+)
+
+// TestIntegration_indexCorrelation exercises the new index attributes (method,
+// columns) end-to-end against a real server, and the exclusions that must hold
+// regardless of the stats window: a REPLICA IDENTITY index and a primary key are
+// never "unused". It also confirms the confidence grades that are window-
+// independent (redundant → catalog_proven; gin/expression/partial → inconclusive).
+// The plain-btree → needs_code_check grade depends on a warm window, so it is only
+// asserted when the window isn't cold.
+func TestIntegration_indexCorrelation(t *testing.T) {
+	d := os.Getenv("PGBOT_TEST_SUPERUSER_DSN")
+	if d == "" {
+		t.Skip("set PGBOT_TEST_SUPERUSER_DSN (a superuser DSN) to run the index-correlation test")
+	}
+	ctx := context.Background()
+	admin, err := pgx.Connect(ctx, d)
+	if err != nil {
+		t.Fatalf("admin connect: %v", err)
+	}
+	defer admin.Close(ctx)
+
+	// A table big enough that its indexes cross pgbot's 16 KB collector floor, with
+	// one of each shape the classifier distinguishes.
+	if _, err := admin.Exec(ctx, `
+		DROP TABLE IF EXISTS public.corr_job, public.corr_ri;
+		CREATE TABLE public.corr_job (id bigint primary key, "externalIdNormalized" text, tags jsonb, status text, customer_id bigint);
+		INSERT INTO public.corr_job
+		  SELECT g, 'ext-'||g, '{"k":"v"}'::jsonb, (ARRAY['open','closed','pending'])[1+g%3], g%500
+		  FROM generate_series(1, 40000) g;
+		CREATE INDEX "corr_Job_externalIdNormalized_idx" ON public.corr_job("externalIdNormalized");
+		CREATE INDEX corr_job_expr_idx    ON public.corr_job(lower(status));
+		CREATE INDEX corr_job_partial_idx ON public.corr_job(customer_id) WHERE status = 'open';
+		CREATE INDEX corr_job_tags_gin    ON public.corr_job USING gin(tags);
+		CREATE INDEX corr_job_cust_status ON public.corr_job(customer_id, status);
+		CREATE INDEX corr_job_cust_only   ON public.corr_job(customer_id);
+		CREATE TABLE public.corr_ri (id int, u text NOT NULL);
+		CREATE UNIQUE INDEX corr_ri_u_key ON public.corr_ri(u);
+		ALTER TABLE public.corr_ri REPLICA IDENTITY USING INDEX corr_ri_u_key;`); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	defer admin.Exec(context.Background(), `DROP TABLE IF EXISTS public.corr_job, public.corr_ri`)
+
+	target, err := conn.Connect(ctx, d)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer target.Close()
+
+	c, err := collect.Run(ctx, target, collect.Options{Interval: time.Second, ASHHz: 0})
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if c.Indexes == nil {
+		t.Fatal("no indexes section")
+	}
+
+	// The new attributes must be populated on the collected indexes.
+	byName := map[string]model.IndexStat{}
+	for _, s := range append(append([]model.IndexStat{}, c.Indexes.Unused...), c.Indexes.Largest...) {
+		byName[s.Name] = s
+	}
+	if g := byName["corr_job_tags_gin"]; g.Method != "gin" {
+		t.Errorf("gin index method = %q, want gin", g.Method)
+	}
+	if ext := byName["corr_Job_externalIdNormalized_idx"]; len(ext.Columns) != 1 || ext.Columns[0] != "externalIdNormalized" {
+		t.Errorf("btree columns = %v, want [externalIdNormalized]; method=%q", ext.Columns, ext.Method)
+	}
+
+	// Window-independent exclusions: replica-identity and PK are never unused.
+	for _, s := range c.Indexes.Unused {
+		if s.Name == "corr_ri_u_key" {
+			t.Error("a REPLICA IDENTITY index must never be reported as unused")
+		}
+		if s.Name == "corr_job_pkey" {
+			t.Error("a primary-key index must never be reported as unused")
+		}
+	}
+
+	rep := correlate.Build(c, nil)
+	grade := map[string]correlate.Confidence{}
+	for _, ix := range rep.Indexes {
+		grade[ix.Index] = ix.Confidence
+	}
+	// Redundant (prefix) is catalog_proven regardless of window.
+	if grade["corr_job_cust_only"] != correlate.CatalogProven {
+		t.Errorf("prefix-redundant index should be catalog_proven, got %q", grade["corr_job_cust_only"])
+	}
+	// GIN / expression / partial are inconclusive regardless of window.
+	for _, n := range []string{"corr_job_tags_gin", "corr_job_expr_idx", "corr_job_partial_idx"} {
+		if grade[n] != correlate.Inconclusive {
+			t.Errorf("%s should be inconclusive, got %q", n, grade[n])
+		}
+	}
+	// Plain btree over bare columns is actionable only with a warm window.
+	if !rep.ColdWindow {
+		if grade["corr_Job_externalIdNormalized_idx"] != correlate.NeedsCodeCheck {
+			t.Errorf("plain btree (warm window) should be needs_code_check, got %q", grade["corr_Job_externalIdNormalized_idx"])
+		}
+		for _, ix := range rep.Indexes {
+			if ix.Index == "corr_Job_externalIdNormalized_idx" {
+				if !contains(ix.SearchTerms, "external_id_normalized") || !contains(ix.SearchTerms, "EXTERNAL_ID_NORMALIZED") {
+					t.Errorf("needs_code_check must emit all case variants: %v", ix.SearchTerms)
+				}
+			}
+		}
+	}
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/collect/indexes.go
+++ b/internal/collect/indexes.go
@@ -23,18 +23,21 @@ var sqlUnindexedFKs string
 type indexesCollector struct{}
 
 type indexRow struct {
-	Schema          string `db:"schema"`
-	Table           string `db:"table"`
-	Index           string `db:"index"`
-	Scans           int64  `db:"scans"`
-	Bytes           int64  `db:"bytes"`
-	Definition      string `db:"definition"`
-	IsPrimary       bool   `db:"is_primary"`
-	IsUnique        bool   `db:"is_unique"`
-	IsExclusion     bool   `db:"is_exclusion"`
-	IsPartial       bool   `db:"is_partial"`
-	IsExpression    bool   `db:"is_expression"`
-	BacksConstraint bool   `db:"backs_constraint"`
+	Schema          string   `db:"schema"`
+	Table           string   `db:"table"`
+	Index           string   `db:"index"`
+	Scans           int64    `db:"scans"`
+	Bytes           int64    `db:"bytes"`
+	Definition      string   `db:"definition"`
+	Method          string   `db:"method"`
+	IsPrimary       bool     `db:"is_primary"`
+	IsUnique        bool     `db:"is_unique"`
+	IsExclusion     bool     `db:"is_exclusion"`
+	IsReplident     bool     `db:"is_replident"`
+	IsPartial       bool     `db:"is_partial"`
+	IsExpression    bool     `db:"is_expression"`
+	BacksConstraint bool     `db:"backs_constraint"`
+	Columns         []string `db:"columns"`
 }
 
 func (indexesCollector) Name() string                     { return "indexes" }
@@ -106,13 +109,17 @@ func (indexesCollector) Assemble(c *model.Context, _ conn.Capabilities, s sample
 	for _, r := range rows {
 		st := model.IndexStat{
 			Schema: r.Schema, Table: r.Table, Name: r.Index, Scans: r.Scans, Bytes: r.Bytes,
-			Definition: r.Definition, Partial: r.IsPartial, Expression: r.IsExpression,
+			Definition: r.Definition, Columns: r.Columns, Method: r.Method,
+			Unique: r.IsUnique, Primary: r.IsPrimary, Partial: r.IsPartial, Expression: r.IsExpression,
 		}
 		// An index that enforces ANY constraint (PK, UNIQUE, EXCLUSION, or a FK's
-		// referenced key) can't be dropped, so it is never "unused" no matter its
-		// scan count. backs_constraint (pg_constraint.conindid) covers all of them;
-		// is_primary/is_unique/is_exclusion are belt-and-suspenders.
-		constraintBacked := r.BacksConstraint || r.IsPrimary || r.IsUnique || r.IsExclusion
+		// referenced key), or that is the table's REPLICA IDENTITY, can't be dropped,
+		// so it is never "unused" no matter its scan count. backs_constraint
+		// (pg_constraint.conindid) covers the constraints; is_primary/is_unique/
+		// is_exclusion are belt-and-suspenders; is_replident guards logical
+		// replication + UPDATE/DELETE row identity (a replica-identity index shows
+		// zero scans on the primary but dropping it breaks replication).
+		constraintBacked := r.BacksConstraint || r.IsPrimary || r.IsUnique || r.IsExclusion || r.IsReplident
 		if r.Scans == 0 && r.Bytes > 16384 && !constraintBacked && len(idx.Unused) < 50 {
 			idx.Unused = append(idx.Unused, st)
 		}

--- a/internal/collect/sql/indexes.sql
+++ b/internal/collect/sql/indexes.sql
@@ -3,22 +3,38 @@
 --   backs_constraint : an index enforcing a PK / UNIQUE / EXCLUSION / FK
 --                      constraint (pg_constraint.conindid) — cannot be dropped.
 --   is_exclusion     : exclusion-constraint index.
+--   is_replident     : the table's REPLICA IDENTITY index — logical replication
+--                      and UPDATE/DELETE row identity depend on it; never "unused".
 --   is_partial       : has a WHERE predicate (serves a narrow path).
 --   is_expression    : indexes an expression, not bare columns.
+--   method           : access method (btree/gin/gist/brin/hash/spgist) — a
+--                      non-btree index can serve a query shape zero-scan can't rule out.
+--   columns          : bare key columns, in order (expression columns skipped),
+--                      so code-correlation can search for the real identifiers.
 SELECT s.schemaname            AS schema,
        s.relname               AS "table",
        s.indexrelname          AS "index",
        coalesce(s.idx_scan, 0) AS scans,
        pg_relation_size(s.indexrelid) AS bytes,
        coalesce(i.indexdef, '') AS definition,
+       am.amname               AS method,
        ix.indisprimary         AS is_primary,
        ix.indisunique          AS is_unique,
        ix.indisexclusion       AS is_exclusion,
+       ix.indisreplident       AS is_replident,
        (ix.indpred IS NOT NULL) AS is_partial,
        (ix.indexprs IS NOT NULL) AS is_expression,
-       EXISTS (SELECT 1 FROM pg_constraint co WHERE co.conindid = s.indexrelid) AS backs_constraint
+       EXISTS (SELECT 1 FROM pg_constraint co WHERE co.conindid = s.indexrelid) AS backs_constraint,
+       coalesce((
+         SELECT array_agg(a.attname::text ORDER BY k.ord)
+         FROM unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ord)
+         JOIN pg_attribute a ON a.attrelid = ix.indrelid AND a.attnum = k.attnum
+         WHERE k.attnum <> 0
+       ), '{}') AS columns
 FROM pg_stat_user_indexes s
 JOIN pg_index ix ON ix.indexrelid = s.indexrelid
+JOIN pg_class ci ON ci.oid = s.indexrelid
+JOIN pg_am am ON am.oid = ci.relam
 LEFT JOIN pg_indexes i
   ON i.schemaname = s.schemaname AND i.tablename = s.relname AND i.indexname = s.indexrelname
 ORDER BY bytes DESC

--- a/internal/correlate/correlate.go
+++ b/internal/correlate/correlate.go
@@ -87,7 +87,11 @@ type IndexReport struct {
 	InconclusiveIf string   `json:"inconclusive_if,omitempty"`
 
 	// DoNotDrop is set on every inconclusive entry (never on the others).
-	DoNotDrop    bool          `json:"do_not_drop,omitempty"`
+	DoNotDrop bool `json:"do_not_drop,omitempty"`
+	// Safety carries the deterministic drop guard as structured data (the same
+	// contract as model.Finding.Safety) so a consumer of the correlation payload
+	// can't lose it — DROP INDEX is destructive on every entry here.
+	Safety       *model.Safety `json:"safety,omitempty"`
 	PriorVerdict *PriorVerdict `json:"prior_verdict,omitempty"`
 	Note         string        `json:"note,omitempty"`
 }
@@ -152,9 +156,9 @@ func Build(c *model.Context, verdicts map[string]PriorVerdict) Report {
 		ir := base(ix, winDays, resetAt)
 		switch {
 		case invalid[k] != "":
-			markCatalog(&ir, "invalid index (indisvalid = false — likely a failed CREATE INDEX CONCURRENTLY); provable from the catalog alone, no code check needed")
+			markCatalog(&ir, "invalid index (indisvalid = false — likely a failed CREATE INDEX CONCURRENTLY); provable from the catalog alone, no code check needed", invalidSafetyGuard())
 		case redundant[k].CoveredBy != "":
-			markCatalog(&ir, redundantReason(redundant[k]))
+			markCatalog(&ir, redundantReason(redundant[k]), redundantSafety(redundant[k]))
 		default:
 			classifyStats(&ir, r.ColdWindow, winDays)
 		}
@@ -172,7 +176,7 @@ func Build(c *model.Context, verdicts map[string]PriorVerdict) Report {
 		if s, ok := stByKey[k]; ok {
 			fillFromStat(&ir, s)
 		}
-		markCatalog(&ir, redundantReason(rd))
+		markCatalog(&ir, redundantReason(rd), redundantSafety(rd))
 		attachVerdict(&ir, verdicts, k, winDays)
 		out = append(out, ir)
 	}
@@ -187,7 +191,7 @@ func Build(c *model.Context, verdicts map[string]PriorVerdict) Report {
 		if s, ok := stByKey[k]; ok {
 			fillFromStat(&ir, s)
 		}
-		markCatalog(&ir, "invalid index (indisvalid = false — likely a failed CREATE INDEX CONCURRENTLY); it is not enforcing anything and can be dropped and rebuilt")
+		markCatalog(&ir, "invalid index (indisvalid = false — likely a failed CREATE INDEX CONCURRENTLY); it is not enforcing anything and can be dropped and rebuilt", invalidSafetyGuard())
 		out = append(out, ir)
 	}
 
@@ -215,14 +219,41 @@ func fillFromStat(ir *IndexReport, s model.IndexStat) {
 	}
 }
 
-func markCatalog(ir *IndexReport, reason string) {
+func markCatalog(ir *IndexReport, reason string, guards ...model.SafetyGuard) {
 	ir.Confidence = CatalogProven
 	ir.Reason = reason
+	ir.Safety = &model.Safety{BlockingCaveats: guards}
+}
+
+// guardProhibition / guardPrecondition mirror findings' helpers — DROP INDEX is
+// destructive on every correlation entry, so each carries a structured guard.
+func guardProhibition(id, action, text string) model.SafetyGuard {
+	return model.SafetyGuard{ID: id, Kind: model.GuardProhibition, Action: action, Text: text}
+}
+
+func guardPrecondition(id, action, text, verify string) model.SafetyGuard {
+	return model.SafetyGuard{ID: id, Kind: model.GuardPrecondition, Action: action, Text: text, Verify: &verify}
 }
 
 func redundantReason(rd model.RedundantIndex) string {
 	return fmt.Sprintf("redundant: its columns are a leading prefix of (or identical to) %s, "+
 		"which already serves these lookups; provable from the catalog alone", rd.CoveredBy)
+}
+
+// redundantSafety is the drop guard for a redundant index. Redundancy is a catalog
+// fact, but "prefix" can hide a difference the covering index doesn't actually
+// cover (extra INCLUDE columns, a different opclass/collation), and index CHOICE is
+// per-node — so the covering index must be confirmed before the drop.
+func redundantSafety(rd model.RedundantIndex) model.SafetyGuard {
+	return guardPrecondition("correlate.redundant_covering", model.ActionDropIndex,
+		"A leading-prefix match can hide a difference the covering index does not cover (extra INCLUDE columns, a different opclass or collation), and index choice is per-node.",
+		fmt.Sprintf("the covering index (%s) has the same INCLUDE columns, opclass, and collation, and is the one used on any replicas, then DROP INDEX CONCURRENTLY", rd.CoveredBy))
+}
+
+func invalidSafetyGuard() model.SafetyGuard {
+	return guardPrecondition("correlate.invalid_no_build", model.ActionDropIndex,
+		"An invalid index is likely a stopped CREATE INDEX CONCURRENTLY, but a build may still be running.",
+		"no CREATE INDEX build is running, then DROP INDEX CONCURRENTLY and rebuild")
 }
 
 // classifyStats grades a zero-scan index that is neither invalid nor redundant.
@@ -247,6 +278,11 @@ func classifyStats(ir *IndexReport, cold bool, winDays *float64) {
 		ir.IfFound = ifFound
 		ir.IfNotFound = ifNotFound(winDays)
 		ir.InconclusiveIf = inconclusiveIf
+		ir.Safety = &model.Safety{BlockingCaveats: []model.SafetyGuard{guardPrecondition(
+			"correlate.needs_code_check", model.ActionDropIndex,
+			"Zero scans in one window on one node; a code search is only half the evidence.",
+			"the columns are absent from query FILTERS (WHERE/JOIN/ORDER BY/GROUP BY), not just SELECT lists — and that no cron/analytics/BI job or other repository uses it (this covered one repo at one commit)",
+		)}}
 	}
 }
 
@@ -255,6 +291,10 @@ func inconclusive(ir *IndexReport, reason string) {
 	ir.Reason = reason
 	ir.DoNotDrop = true
 	ir.Note = doNotDrop
+	ir.Safety = &model.Safety{BlockingCaveats: []model.SafetyGuard{guardProhibition(
+		"correlate.inconclusive", model.ActionDropIndex,
+		doNotDrop+" "+reason+". An empty code search does not change that.",
+	)}}
 }
 
 func ifNotFound(winDays *float64) string {

--- a/internal/correlate/correlate.go
+++ b/internal/correlate/correlate.go
@@ -132,6 +132,15 @@ func Build(c *model.Context, verdicts map[string]PriorVerdict) Report {
 	r.ReplicationActive = replicationActive(c)
 	winDays := c.Window.StatsWindowDays
 	r.StatsWindowDays = winDays
+	// effWinDays is the effective observation window for staleness: the stats
+	// window if reset is known, else the age since postmaster start. It is (almost)
+	// always available on a live server, so a verdict's staleness can be judged even
+	// when stats were never reset (StatsWindowDays would be nil there).
+	effWinDays := winDays
+	if effWinDays == nil && c.Window.WindowAgeSeconds != nil {
+		d := float64(*c.Window.WindowAgeSeconds) / 86400
+		effWinDays = &d
+	}
 	resetAt := c.Window.StatsResetAt
 	if c.Indexes == nil {
 		return r
@@ -168,7 +177,7 @@ func Build(c *model.Context, verdicts map[string]PriorVerdict) Report {
 		default:
 			classifyStats(&ir, r.ColdWindow, winDays)
 		}
-		attachVerdict(&ir, verdicts, k, winDays, c.CollectedAt)
+		attachVerdict(&ir, verdicts, k, winDays, effWinDays, c.CollectedAt)
 		out = append(out, ir)
 	}
 	// 2) Redundant indexes not already emitted (they may have scans).
@@ -183,7 +192,7 @@ func Build(c *model.Context, verdicts map[string]PriorVerdict) Report {
 			fillFromStat(&ir, s)
 		}
 		markCatalog(&ir, redundantReason(rd), redundantSafety(rd))
-		attachVerdict(&ir, verdicts, k, winDays, c.CollectedAt)
+		attachVerdict(&ir, verdicts, k, winDays, effWinDays, c.CollectedAt)
 		out = append(out, ir)
 	}
 	// 3) Invalid indexes not already emitted.
@@ -327,7 +336,7 @@ func windowStr(winDays *float64) string {
 // and a stale verdict must never increase confidence — it only ever adds context.
 // The strengthened wording states that observation continued; it never authorizes
 // a drop, and the precondition guard stays attached regardless.
-func attachVerdict(ir *IndexReport, verdicts map[string]PriorVerdict, k string, winDays *float64, now time.Time) {
+func attachVerdict(ir *IndexReport, verdicts map[string]PriorVerdict, k string, winDays, effWinDays *float64, now time.Time) {
 	v, ok := verdicts[k]
 	if !ok {
 		return
@@ -338,9 +347,10 @@ func attachVerdict(ir *IndexReport, verdicts map[string]PriorVerdict, k string, 
 	}
 	vv := v
 	vv.AgeDays = int(ageDays + 0.5)
-	// Stale once older than the current window. With an unknown window we cannot
-	// establish that the verdict is the fresher signal, so treat it as stale.
-	vv.Stale = winDays == nil || ageDays > *winDays
+	// Stale once older than the effective observation window (since reset, else
+	// since postmaster start). Only if that window is truly unknowable do we fall
+	// back to treating the verdict as stale (we can't confirm it's the fresher signal).
+	vv.Stale = effWinDays == nil || ageDays > *effWinDays
 	ir.PriorVerdict = &vv
 
 	// Only a fresh "not found in code" verdict on a needs_code_check index adds

--- a/internal/correlate/correlate.go
+++ b/internal/correlate/correlate.go
@@ -1,0 +1,439 @@
+// Package correlate turns pgbot's index observations into an actionable,
+// confidence-graded payload an agent can act on WITHOUT pgbot ever reading the
+// repository. pgbot knows the database side (which index, which columns, whether
+// it's provable from the catalog alone); the agent has the code. This package
+// emits what to search for and exactly how to interpret the result.
+//
+// Three confidence levels, and the boundary between them is load-bearing:
+//
+//   - catalog_proven  — provable from the catalog alone (invalid or
+//     redundant/duplicate). No stats window, no code check; safe to drop.
+//   - needs_code_check — zero scans, plain btree over bare columns. Actionable
+//     ONLY in combination with the code: grep the search terms, apply if_found /
+//     if_not_found.
+//   - inconclusive    — GIN/GiST/BRIN, expression, partial, or a cold window. A
+//     query shape that simply hasn't run can be served by these, so an empty code
+//     search proves nothing. NEVER promoted to actionable.
+package correlate
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/pgrundev/pgbot/internal/model"
+)
+
+// Confidence is the strength of the "this index is droppable" claim.
+type Confidence string
+
+const (
+	CatalogProven  Confidence = "catalog_proven"
+	NeedsCodeCheck Confidence = "needs_code_check"
+	Inconclusive   Confidence = "inconclusive"
+)
+
+// The instruction and outcome strings are fixed wording — the WHERE-vs-SELECT
+// distinction in particular is the single most important line in the payload:
+// without it an agent finds a column in a SELECT list and wrongly reports "used".
+const (
+	instruction = "Search the repository for these identifiers in filtering positions only: " +
+		"WHERE clauses, JOIN ... ON conditions, ORDER BY, GROUP BY, and ORM equivalents " +
+		"(where, orderBy, groupBy, findUnique, findFirst, findMany filters, cursor). " +
+		"An appearance in SELECT lists, return types, model definitions, serializers, or " +
+		"migration files does NOT indicate index usage."
+	ifFound        = "Index is used by an infrequent path not captured in the stats window. Do not drop."
+	inconclusiveIf = "The identifier appears inside dynamically constructed SQL (string concatenation, " +
+		"raw query builders, dynamic filter maps). No conclusion possible from static search."
+	doNotDrop = "Do not DROP INDEX on this evidence."
+)
+
+// PriorVerdict is a code-search result recorded on an earlier run (from the
+// index_verdicts store). Carrying it forward is what turns a one-off grep into a
+// compounding asset: the same verdict against a growing stats window gets stronger.
+type PriorVerdict struct {
+	Verdict         string    `json:"verdict"`
+	Source          string    `json:"source,omitempty"`
+	RepoRef         string    `json:"repo_ref,omitempty"`
+	CheckedAt       time.Time `json:"checked_at"`
+	StatsWindowDays *float64  `json:"stats_window_days_then,omitempty"`
+}
+
+// IndexReport is one index's correlation entry.
+type IndexReport struct {
+	Index           string     `json:"index"`
+	Table           string     `json:"table,omitempty"`
+	Schema          string     `json:"schema,omitempty"`
+	Columns         []string   `json:"columns,omitempty"`
+	Kind            string     `json:"kind,omitempty"` // access method
+	IsUnique        bool       `json:"is_unique"`
+	IsPartial       bool       `json:"is_partial"`
+	IsExpression    bool       `json:"is_expression"`
+	SizeBytes       int64      `json:"size_bytes"`
+	Scans           int64      `json:"scans"`
+	StatsWindowDays *float64   `json:"stats_window_days,omitempty"`
+	StatsResetAt    *time.Time `json:"stats_reset_at,omitempty"`
+
+	Confidence Confidence `json:"confidence"`
+	Reason     string     `json:"reason"`
+
+	// Populated only for needs_code_check.
+	SearchTerms    []string `json:"search_terms,omitempty"`
+	Instruction    string   `json:"instruction,omitempty"`
+	IfFound        string   `json:"if_found,omitempty"`
+	IfNotFound     string   `json:"if_not_found,omitempty"`
+	InconclusiveIf string   `json:"inconclusive_if,omitempty"`
+
+	// DoNotDrop is set on every inconclusive entry (never on the others).
+	DoNotDrop    bool          `json:"do_not_drop,omitempty"`
+	PriorVerdict *PriorVerdict `json:"prior_verdict,omitempty"`
+	Note         string        `json:"note,omitempty"`
+}
+
+// Report is the whole correlation payload.
+type Report struct {
+	Fingerprint       string        `json:"fingerprint,omitempty"`
+	ColdWindow        bool          `json:"cold_window"`
+	ReplicationActive bool          `json:"replication_active"`
+	StatsWindowDays   *float64      `json:"stats_window_days,omitempty"`
+	Indexes           []IndexReport `json:"indexes"`
+	Note              string        `json:"note"`
+}
+
+const reportNote = "pgbot never reads your repository and never drops anything. " +
+	"catalog_proven = safe to drop from the catalog alone (no code check). " +
+	"needs_code_check = search the terms per the instruction, then apply if_found/if_not_found. " +
+	"inconclusive = do NOT drop on this evidence, and an empty code search does not change that."
+
+func key(schema, name string) string { return schema + "." + name }
+
+// Build assembles the correlation report from a collected Context. verdicts is
+// the prior code-search verdicts for this database (keyed by "schema.index"),
+// loaded from the store by the caller — pass nil if none.
+func Build(c *model.Context, verdicts map[string]PriorVerdict) Report {
+	r := Report{Note: reportNote}
+	if c == nil {
+		return r
+	}
+	r.Fingerprint = c.Fingerprint
+	r.ColdWindow = c.Window.ColdWindow()
+	r.ReplicationActive = replicationActive(c)
+	winDays := c.Window.StatsWindowDays
+	r.StatsWindowDays = winDays
+	resetAt := c.Window.StatsResetAt
+	if c.Indexes == nil {
+		return r
+	}
+
+	invalid := invalidIndexKeys(c) // key -> table
+	redundant := map[string]model.RedundantIndex{}
+	for _, rd := range c.Indexes.Redundant {
+		redundant[key(rd.Schema, rd.Name)] = rd
+	}
+	// A by-name lookup so redundant/invalid entries that aren't in the zero-scan
+	// set can still be enriched with columns/kind if we happened to observe them.
+	stByKey := map[string]model.IndexStat{}
+	for _, s := range c.Indexes.Largest {
+		stByKey[key(s.Schema, s.Name)] = s
+	}
+	for _, s := range c.Indexes.Unused {
+		stByKey[key(s.Schema, s.Name)] = s
+	}
+
+	seen := map[string]bool{}
+	var out []IndexReport
+
+	// 1) Zero-scan unused indexes — the main correlation surface.
+	for _, ix := range c.Indexes.Unused {
+		k := key(ix.Schema, ix.Name)
+		seen[k] = true
+		ir := base(ix, winDays, resetAt)
+		switch {
+		case invalid[k] != "":
+			markCatalog(&ir, "invalid index (indisvalid = false — likely a failed CREATE INDEX CONCURRENTLY); provable from the catalog alone, no code check needed")
+		case redundant[k].CoveredBy != "":
+			markCatalog(&ir, redundantReason(redundant[k]))
+		default:
+			classifyStats(&ir, r.ColdWindow, winDays)
+		}
+		attachVerdict(&ir, verdicts, k, winDays)
+		out = append(out, ir)
+	}
+	// 2) Redundant indexes not already emitted (they may have scans).
+	for _, rd := range c.Indexes.Redundant {
+		k := key(rd.Schema, rd.Name)
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		ir := IndexReport{Index: rd.Name, Schema: rd.Schema, Table: rd.Table, SizeBytes: rd.Bytes, StatsWindowDays: winDays, StatsResetAt: resetAt}
+		if s, ok := stByKey[k]; ok {
+			fillFromStat(&ir, s)
+		}
+		markCatalog(&ir, redundantReason(rd))
+		attachVerdict(&ir, verdicts, k, winDays)
+		out = append(out, ir)
+	}
+	// 3) Invalid indexes not already emitted.
+	for k, table := range invalid {
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		schema, name := splitKey(k)
+		ir := IndexReport{Index: name, Schema: schema, Table: table, StatsWindowDays: winDays, StatsResetAt: resetAt}
+		if s, ok := stByKey[k]; ok {
+			fillFromStat(&ir, s)
+		}
+		markCatalog(&ir, "invalid index (indisvalid = false — likely a failed CREATE INDEX CONCURRENTLY); it is not enforcing anything and can be dropped and rebuilt")
+		out = append(out, ir)
+	}
+
+	sortReports(out)
+	r.Indexes = out
+	return r
+}
+
+func base(ix model.IndexStat, winDays *float64, resetAt *time.Time) IndexReport {
+	return IndexReport{
+		Index: ix.Name, Table: ix.Table, Schema: ix.Schema,
+		Columns: ix.Columns, Kind: ix.Method,
+		IsUnique: ix.Unique, IsPartial: ix.Partial, IsExpression: ix.Expression,
+		SizeBytes: ix.Bytes, Scans: ix.Scans,
+		StatsWindowDays: winDays, StatsResetAt: resetAt,
+	}
+}
+
+func fillFromStat(ir *IndexReport, s model.IndexStat) {
+	ir.Columns, ir.Kind = s.Columns, s.Method
+	ir.IsUnique, ir.IsPartial, ir.IsExpression = s.Unique, s.Partial, s.Expression
+	ir.Scans = s.Scans
+	if ir.SizeBytes == 0 {
+		ir.SizeBytes = s.Bytes
+	}
+}
+
+func markCatalog(ir *IndexReport, reason string) {
+	ir.Confidence = CatalogProven
+	ir.Reason = reason
+}
+
+func redundantReason(rd model.RedundantIndex) string {
+	return fmt.Sprintf("redundant: its columns are a leading prefix of (or identical to) %s, "+
+		"which already serves these lookups; provable from the catalog alone", rd.CoveredBy)
+}
+
+// classifyStats grades a zero-scan index that is neither invalid nor redundant.
+// A cold window or any non-btree/expression/partial index is inconclusive and
+// stays inconclusive regardless of any code search. Only a plain btree over bare
+// columns earns needs_code_check and a correlation payload.
+func classifyStats(ir *IndexReport, cold bool, winDays *float64) {
+	switch {
+	case cold:
+		inconclusive(ir, "cold statistics window — scan counts just started from zero, so 'unused' is not yet meaningful")
+	case ir.Kind != "" && ir.Kind != "btree":
+		inconclusive(ir, ir.Kind+" index — may serve a query shape (containment, similarity, range) that a plain scan count cannot rule out")
+	case ir.IsExpression:
+		inconclusive(ir, "expression index — serves a computed expression, not a bare column; a code search for column names cannot confirm it is unused")
+	case ir.IsPartial:
+		inconclusive(ir, "partial index — may serve a narrow but critical path that runs rarely")
+	default:
+		ir.Confidence = NeedsCodeCheck
+		ir.Reason = "zero scans in the observed window; plain btree over bare columns — actionable only after confirming the columns are absent from query filters in the code"
+		ir.SearchTerms = searchTermsFor(ir.Columns)
+		ir.Instruction = instruction
+		ir.IfFound = ifFound
+		ir.IfNotFound = ifNotFound(winDays)
+		ir.InconclusiveIf = inconclusiveIf
+	}
+}
+
+func inconclusive(ir *IndexReport, reason string) {
+	ir.Confidence = Inconclusive
+	ir.Reason = reason
+	ir.DoNotDrop = true
+	ir.Note = doNotDrop
+}
+
+func ifNotFound(winDays *float64) string {
+	return fmt.Sprintf("Dead weight confirmed by two independent sources (zero scans + absent from code filters). "+
+		"Remaining caveats: (1) stats window is %s; (2) the index may be used by cron jobs, analytics tools, "+
+		"BI dashboards, or a different repository not searched here.", windowStr(winDays))
+}
+
+func windowStr(winDays *float64) string {
+	if winDays == nil {
+		return "of unknown length"
+	}
+	if *winDays < 1 {
+		return "under a day"
+	}
+	return fmt.Sprintf("%.0f days", *winDays)
+}
+
+// attachVerdict carries a stored code-search verdict forward. When a prior
+// "not found in code" verdict meets a still-zero-scan needs_code_check index over
+// a window that has since grown, that is the compounding signal — surface it.
+func attachVerdict(ir *IndexReport, verdicts map[string]PriorVerdict, k string, winDays *float64) {
+	v, ok := verdicts[k]
+	if !ok {
+		return
+	}
+	vv := v
+	ir.PriorVerdict = &vv
+	if ir.Confidence != NeedsCodeCheck || v.Verdict != "not_found_in_code" {
+		return
+	}
+	note := fmt.Sprintf("Evidence has strengthened: absent from code filters as of %s", v.CheckedAt.Format("2006-01-02"))
+	if v.RepoRef != "" {
+		note += " (" + v.RepoRef + ")"
+	}
+	if v.StatsWindowDays != nil && winDays != nil && *winDays > *v.StatsWindowDays {
+		note += fmt.Sprintf("; the zero-scan window has grown from %.0fd to %.0fd since", *v.StatsWindowDays, *winDays)
+	}
+	note += "."
+	ir.Note = note
+}
+
+// searchTermsFor emits, for each bare column, the camelCase / snake_case /
+// PascalCase / CONSTANT_CASE variants plus the raw name, deduped — pgbot knows
+// the database name; the agent shouldn't have to guess the codebase convention.
+func searchTermsFor(cols []string) []string {
+	var out []string
+	seen := map[string]bool{}
+	push := func(s string) {
+		if s == "" || seen[s] {
+			return
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	for _, col := range cols {
+		push(col)
+		for _, v := range caseVariants(splitWords(col)) {
+			push(v)
+		}
+	}
+	return out
+}
+
+// splitWords breaks an identifier into lowercase words on underscores/dashes and
+// at camelCase boundaries (including ACRONYM→Word transitions).
+func splitWords(s string) []string {
+	var words []string
+	var cur []rune
+	flush := func() {
+		if len(cur) > 0 {
+			words = append(words, strings.ToLower(string(cur)))
+			cur = nil
+		}
+	}
+	rs := []rune(s)
+	for i, r := range rs {
+		switch {
+		case r == '_' || r == '-' || r == ' ':
+			flush()
+			continue
+		case unicode.IsUpper(r) && i > 0:
+			prev := rs[i-1]
+			if unicode.IsLower(prev) || unicode.IsDigit(prev) {
+				flush() // fooBar -> foo | Bar
+			} else if unicode.IsUpper(prev) && i+1 < len(rs) && unicode.IsLower(rs[i+1]) {
+				flush() // HTTPServer -> HTTP | Server
+			}
+		}
+		cur = append(cur, r)
+	}
+	flush()
+	return words
+}
+
+func caseVariants(words []string) []string {
+	if len(words) == 0 {
+		return nil
+	}
+	camel := words[0]
+	pascal := title(words[0])
+	for _, w := range words[1:] {
+		camel += title(w)
+		pascal += title(w)
+	}
+	snake := strings.Join(words, "_")
+	constant := strings.ToUpper(snake)
+	return []string{camel, snake, pascal, constant}
+}
+
+func title(w string) string {
+	if w == "" {
+		return ""
+	}
+	rs := []rune(w)
+	return strings.ToUpper(string(rs[0])) + string(rs[1:])
+}
+
+func replicationActive(c *model.Context) bool {
+	return c.Replication != nil && (len(c.Replication.Replicas) > 0 || c.Replication.IsReplica)
+}
+
+// invalidIndexKeys returns "schema.index" -> table for every invalid index in the
+// schema fingerprint. Identity is "schema.table.index".
+func invalidIndexKeys(c *model.Context) map[string]string {
+	out := map[string]string{}
+	if c.Schema == nil {
+		return out
+	}
+	for _, o := range c.Schema.Objects {
+		if o.Kind != "index" || !o.Invalid {
+			continue
+		}
+		schema, table, name := splitIdentity(o.Identity)
+		if name == "" {
+			continue
+		}
+		out[key(schema, name)] = table
+	}
+	return out
+}
+
+func splitIdentity(id string) (schema, table, name string) {
+	parts := strings.Split(id, ".")
+	switch {
+	case len(parts) >= 3:
+		return parts[0], strings.Join(parts[1:len(parts)-1], "."), parts[len(parts)-1]
+	case len(parts) == 2:
+		return parts[0], "", parts[1]
+	case len(parts) == 1:
+		return "", "", parts[0]
+	}
+	return "", "", ""
+}
+
+func splitKey(k string) (schema, name string) {
+	if i := strings.Index(k, "."); i >= 0 {
+		return k[:i], k[i+1:]
+	}
+	return "", k
+}
+
+func confidenceRank(c Confidence) int {
+	switch c {
+	case CatalogProven:
+		return 0
+	case NeedsCodeCheck:
+		return 1
+	default:
+		return 2
+	}
+}
+
+func sortReports(rs []IndexReport) {
+	sort.SliceStable(rs, func(i, j int) bool {
+		ri, rj := confidenceRank(rs[i].Confidence), confidenceRank(rs[j].Confidence)
+		if ri != rj {
+			return ri < rj
+		}
+		return rs[i].SizeBytes > rs[j].SizeBytes
+	})
+}

--- a/internal/correlate/correlate.go
+++ b/internal/correlate/correlate.go
@@ -7,7 +7,8 @@
 // Three confidence levels, and the boundary between them is load-bearing:
 //
 //   - catalog_proven  — provable from the catalog alone (invalid or
-//     redundant/duplicate). No stats window, no code check; safe to drop.
+//     redundant/duplicate). No stats window, no code check; the catalog justifies
+//     the drop, still subject to the guard (covering-index / no-running-build).
 //   - needs_code_check — zero scans, plain btree over bare columns. Actionable
 //     ONLY in combination with the code: grep the search terms, apply if_found /
 //     if_not_found.
@@ -59,6 +60,11 @@ type PriorVerdict struct {
 	RepoRef         string    `json:"repo_ref,omitempty"`
 	CheckedAt       time.Time `json:"checked_at"`
 	StatsWindowDays *float64  `json:"stats_window_days_then,omitempty"`
+	// Stale is set when the verdict is older than the current stats window — the
+	// code may have changed since, so it is no longer the fresher signal. A stale
+	// verdict is kept as context but must never increase confidence.
+	Stale   bool `json:"stale"`
+	AgeDays int  `json:"age_days"`
 }
 
 // IndexReport is one index's correlation entry.
@@ -107,8 +113,8 @@ type Report struct {
 }
 
 const reportNote = "pgbot never reads your repository and never drops anything. " +
-	"catalog_proven = safe to drop from the catalog alone (no code check). " +
-	"needs_code_check = search the terms per the instruction, then apply if_found/if_not_found. " +
+	"catalog_proven = the catalog alone justifies the drop, still subject to the guard. " +
+	"needs_code_check = search the terms per the instruction, then apply if_found/if_not_found, subject to the guard. " +
 	"inconclusive = do NOT drop on this evidence, and an empty code search does not change that."
 
 func key(schema, name string) string { return schema + "." + name }
@@ -162,7 +168,7 @@ func Build(c *model.Context, verdicts map[string]PriorVerdict) Report {
 		default:
 			classifyStats(&ir, r.ColdWindow, winDays)
 		}
-		attachVerdict(&ir, verdicts, k, winDays)
+		attachVerdict(&ir, verdicts, k, winDays, c.CollectedAt)
 		out = append(out, ir)
 	}
 	// 2) Redundant indexes not already emitted (they may have scans).
@@ -177,7 +183,7 @@ func Build(c *model.Context, verdicts map[string]PriorVerdict) Report {
 			fillFromStat(&ir, s)
 		}
 		markCatalog(&ir, redundantReason(rd), redundantSafety(rd))
-		attachVerdict(&ir, verdicts, k, winDays)
+		attachVerdict(&ir, verdicts, k, winDays, c.CollectedAt)
 		out = append(out, ir)
 	}
 	// 3) Invalid indexes not already emitted.
@@ -298,9 +304,11 @@ func inconclusive(ir *IndexReport, reason string) {
 }
 
 func ifNotFound(winDays *float64) string {
-	return fmt.Sprintf("Dead weight confirmed by two independent sources (zero scans + absent from code filters). "+
-		"Remaining caveats: (1) stats window is %s; (2) the index may be used by cron jobs, analytics tools, "+
-		"BI dashboards, or a different repository not searched here.", windowStr(winDays))
+	return fmt.Sprintf("Two independent signals agree (zero scans + absent from code filters), but neither is proof: "+
+		"(1) the stats window is %s; (2) a MONTHLY, QUARTERLY, or ANNUAL job — billing cycles, compliance exports, "+
+		"year-end batches — will not appear in it; a 40-day window does not see a quarterly job; (3) cron, analytics, "+
+		"or BI tools, or a repository not searched here, may still use it. The precondition to drop still applies.",
+		windowStr(winDays))
 }
 
 func windowStr(winDays *float64) string {
@@ -313,28 +321,66 @@ func windowStr(winDays *float64) string {
 	return fmt.Sprintf("%.0f days", *winDays)
 }
 
-// attachVerdict carries a stored code-search verdict forward. When a prior
-// "not found in code" verdict meets a still-zero-scan needs_code_check index over
-// a window that has since grown, that is the compounding signal — surface it.
-func attachVerdict(ir *IndexReport, verdicts map[string]PriorVerdict, k string, winDays *float64) {
+// attachVerdict carries a stored code-search verdict forward. A verdict records
+// what one repository looked like at one commit, at one moment: it is STALE once
+// older than the current stats window (the observation is now the fresher signal),
+// and a stale verdict must never increase confidence — it only ever adds context.
+// The strengthened wording states that observation continued; it never authorizes
+// a drop, and the precondition guard stays attached regardless.
+func attachVerdict(ir *IndexReport, verdicts map[string]PriorVerdict, k string, winDays *float64, now time.Time) {
 	v, ok := verdicts[k]
 	if !ok {
 		return
 	}
+	ageDays := now.Sub(v.CheckedAt).Hours() / 24
+	if ageDays < 0 {
+		ageDays = 0
+	}
 	vv := v
+	vv.AgeDays = int(ageDays + 0.5)
+	// Stale once older than the current window. With an unknown window we cannot
+	// establish that the verdict is the fresher signal, so treat it as stale.
+	vv.Stale = winDays == nil || ageDays > *winDays
 	ir.PriorVerdict = &vv
+
+	// Only a fresh "not found in code" verdict on a needs_code_check index adds
+	// corroboration. Everything else just carries the structured verdict.
 	if ir.Confidence != NeedsCodeCheck || v.Verdict != "not_found_in_code" {
 		return
 	}
-	note := fmt.Sprintf("Evidence has strengthened: absent from code filters as of %s", v.CheckedAt.Format("2006-01-02"))
+	if vv.Stale {
+		ir.Note = stalenessNote(v, vv.AgeDays)
+		return
+	}
+	ir.Note = corroborationNote(v, winDays)
+}
+
+// stalenessNote states the verdict's age and that the repo may have changed —
+// explicitly, in output, never as clearance.
+func stalenessNote(v PriorVerdict, ageDays int) string {
+	ref := ""
 	if v.RepoRef != "" {
-		note += " (" + v.RepoRef + ")"
+		ref = " (commit " + v.RepoRef + ")"
 	}
+	return fmt.Sprintf("A prior code search found no filter references, but that check is %d days old%s — "+
+		"the repository may have changed since, so it is no longer the fresher signal. It stays as context, not corroboration.",
+		ageDays, ref)
+}
+
+// corroborationNote states that observation continued and the code check still
+// holds — corroboration, not authorization. Must not contain any go-ahead phrasing.
+func corroborationNote(v PriorVerdict, winDays *float64) string {
+	ref := ""
+	if v.RepoRef != "" {
+		ref = ", commit " + v.RepoRef
+	}
+	grew := ""
 	if v.StatsWindowDays != nil && winDays != nil && *winDays > *v.StatsWindowDays {
-		note += fmt.Sprintf("; the zero-scan window has grown from %.0fd to %.0fd since", *v.StatsWindowDays, *winDays)
+		grew = fmt.Sprintf(" over a window that has grown from %.0fd to %.0fd", *v.StatsWindowDays, *winDays)
 	}
-	note += "."
-	ir.Note = note
+	return fmt.Sprintf("A prior code search (recorded %s%s) found no filter references, and the index has stayed "+
+		"zero-scan since%s. This is corroboration, not clearance — the precondition below still applies.",
+		v.CheckedAt.Format("2006-01-02"), ref, grew)
 }
 
 // searchTermsFor emits, for each bare column, the camelCase / snake_case /

--- a/internal/correlate/correlate_test.go
+++ b/internal/correlate/correlate_test.go
@@ -222,6 +222,38 @@ func TestSort_catalogFirstInconclusiveLast(t *testing.T) {
 	}
 }
 
+// TestSafety_correlateGuards asserts every correlation entry carries a structured
+// drop guard, keyed on a stable ID — including the catalog_proven redundant entry,
+// which must carry the per-node/INCLUDE guard (Step 5) that lives on the finding.
+func TestSafety_correlateGuards(t *testing.T) {
+	c := ctxWith([]model.IndexStat{
+		{Schema: "public", Table: "t", Name: "plain", Method: "btree", Columns: []string{"a"}, Bytes: 1 << 21},
+		{Schema: "public", Table: "t", Name: "gin", Method: "gin", Columns: []string{"tags"}, Bytes: 1 << 21},
+	}, func(c *model.Context) {
+		c.Indexes.Redundant = []model.RedundantIndex{{Schema: "public", Table: "t", Name: "dup", CoveredBy: "cov"}}
+	})
+	r := Build(c, nil)
+	check := func(name, guardID, kind string) {
+		ix := find(r, name)
+		if ix == nil || ix.Safety == nil || len(ix.Safety.BlockingCaveats) == 0 {
+			t.Fatalf("%s is missing a structured safety guard: %+v", name, ix)
+		}
+		g := ix.Safety.BlockingCaveats[0]
+		if g.ID != guardID {
+			t.Errorf("%s guard id = %q, want %q", name, g.ID, guardID)
+		}
+		if g.Action != model.ActionDropIndex {
+			t.Errorf("%s guard action = %q, want DROP INDEX", name, g.Action)
+		}
+		if g.Kind != kind {
+			t.Errorf("%s guard kind = %q, want %q", name, g.Kind, kind)
+		}
+	}
+	check("plain", "correlate.needs_code_check", model.GuardPrecondition)
+	check("gin", "correlate.inconclusive", model.GuardProhibition)
+	check("dup", "correlate.redundant_covering", model.GuardPrecondition)
+}
+
 func contains(ss []string, s string) bool {
 	for _, x := range ss {
 		if x == s {

--- a/internal/correlate/correlate_test.go
+++ b/internal/correlate/correlate_test.go
@@ -188,20 +188,108 @@ func TestInvalidIndex_isCatalogProven(t *testing.T) {
 	}
 }
 
-func TestVerdict_strengthensNeedsCodeCheck(t *testing.T) {
+// forbiddenPhrases must never appear in any correlation output, at any confidence.
+var forbiddenPhrases = []string{"safe to drop", "confirmed unused", "you can now remove", "you can remove", "go ahead and drop", "ok to drop"}
+
+func assertNoAuthorization(t *testing.T, ix *IndexReport) {
+	t.Helper()
+	blob := strings.ToLower(ix.Reason + " " + ix.Note + " " + ix.IfFound + " " + ix.IfNotFound)
+	if ix.Safety != nil {
+		for _, g := range ix.Safety.BlockingCaveats {
+			blob += " " + strings.ToLower(g.Text)
+			if g.Verify != nil {
+				blob += " " + strings.ToLower(*g.Verify)
+			}
+		}
+	}
+	for _, p := range forbiddenPhrases {
+		if strings.Contains(blob, p) {
+			t.Errorf("output for %s contains authorization phrase %q — must never read as a go-ahead", ix.Index, p)
+		}
+	}
+}
+
+// B2/B3: a FRESH not_found verdict corroborates (states observation continued,
+// shows window growth) but never authorizes, and the precondition guard persists.
+func TestVerdict_freshCorroboratesNeverAuthorizes(t *testing.T) {
+	checked := time.Unix(1_700_000_000, 0)
 	c := ctxWith([]model.IndexStat{
 		{Schema: "public", Table: "t", Name: "t_a_idx", Method: "btree", Columns: []string{"a"}, Bytes: 1 << 21},
-	}, nil)
+	}, func(c *model.Context) {
+		c.Window.StatsWindowDays = f64(45)
+		c.CollectedAt = checked.Add(20 * 24 * time.Hour) // 20d old vs 45d window → fresh
+	})
 	verdicts := map[string]PriorVerdict{
-		"public.t_a_idx": {Verdict: "not_found_in_code", RepoRef: "abc123", CheckedAt: time.Unix(1_700_000_000, 0), StatsWindowDays: f64(12)},
+		"public.t_a_idx": {Verdict: "not_found_in_code", RepoRef: "abc123", CheckedAt: checked, StatsWindowDays: f64(12)},
 	}
 	ix := find(Build(c, verdicts), "t_a_idx")
 	if ix == nil || ix.PriorVerdict == nil {
 		t.Fatalf("prior verdict should be attached, got %+v", ix)
 	}
-	if !strings.Contains(ix.Note, "strengthened") || !strings.Contains(ix.Note, "12d") || !strings.Contains(ix.Note, "45d") {
-		t.Errorf("note should show window growth 12d -> 45d: %q", ix.Note)
+	if ix.PriorVerdict.Stale {
+		t.Error("a 20-day-old verdict against a 45-day window must not be stale")
 	}
+	if !strings.Contains(ix.Note, "12d to 45d") || !strings.Contains(ix.Note, "corroboration") {
+		t.Errorf("fresh note should show growth + read as corroboration: %q", ix.Note)
+	}
+	if ix.Safety == nil || ix.Safety.BlockingCaveats[0].Kind != model.GuardPrecondition {
+		t.Errorf("precondition guard must persist through the verdict: %+v", ix.Safety)
+	}
+	assertNoAuthorization(t, ix)
+}
+
+// B2: a verdict older than the window is STALE — stated in output, no strengthening.
+func TestVerdict_staleStatedAndDoesNotStrengthen(t *testing.T) {
+	checked := time.Unix(1_700_000_000, 0)
+	c := ctxWith([]model.IndexStat{
+		{Schema: "public", Table: "t", Name: "t_a_idx", Method: "btree", Columns: []string{"a"}, Bytes: 1 << 21},
+	}, func(c *model.Context) {
+		c.Window.StatsWindowDays = f64(30)
+		c.CollectedAt = checked.Add(47 * 24 * time.Hour) // 47d old vs 30d window → stale
+	})
+	verdicts := map[string]PriorVerdict{
+		"public.t_a_idx": {Verdict: "not_found_in_code", RepoRef: "abc123", CheckedAt: checked, StatsWindowDays: f64(12)},
+	}
+	ix := find(Build(c, verdicts), "t_a_idx")
+	if ix == nil || ix.PriorVerdict == nil || !ix.PriorVerdict.Stale {
+		t.Fatalf("verdict older than the window must be stale: %+v", ix.PriorVerdict)
+	}
+	if ix.PriorVerdict.AgeDays != 47 {
+		t.Errorf("age = %dd, want 47", ix.PriorVerdict.AgeDays)
+	}
+	if !strings.Contains(ix.Note, "47 days old") || !strings.Contains(strings.ToLower(ix.Note), "may have changed") {
+		t.Errorf("staleness must be stated in output: %q", ix.Note)
+	}
+	if strings.Contains(ix.Note, "corroboration,") || strings.Contains(ix.Note, "grown") {
+		t.Errorf("a stale verdict must not strengthen: %q", ix.Note)
+	}
+	assertNoAuthorization(t, ix)
+}
+
+// B4 hard invariant: inconclusive is NEVER promoted, at the extreme — 365-day
+// window + not_found verdict → still inconclusive, prohibition guard intact.
+func TestVerdict_inconclusiveNeverPromoted_365d(t *testing.T) {
+	checked := time.Unix(1_700_000_000, 0)
+	c := ctxWith([]model.IndexStat{
+		{Schema: "public", Table: "t", Name: "gin_idx", Method: "gin", Columns: []string{"tags"}, Bytes: 1 << 21},
+	}, func(c *model.Context) {
+		c.Window.StatsWindowDays = f64(365)
+		c.CollectedAt = checked.Add(10 * 24 * time.Hour)
+	})
+	verdicts := map[string]PriorVerdict{
+		"public.gin_idx": {Verdict: "not_found_in_code", CheckedAt: checked, StatsWindowDays: f64(360)},
+	}
+	ix := find(Build(c, verdicts), "gin_idx")
+	if ix == nil || ix.Confidence != Inconclusive {
+		t.Fatalf("inconclusive must stay inconclusive at 365d with a not_found verdict, got %+v", ix)
+	}
+	if !ix.DoNotDrop {
+		t.Error("still do-not-drop")
+	}
+	if ix.Safety == nil || ix.Safety.BlockingCaveats[0].Kind != model.GuardProhibition {
+		t.Errorf("prohibition guard must remain: %+v", ix.Safety)
+	}
+	assertNoAuthorization(t, ix)
 }
 
 func TestSort_catalogFirstInconclusiveLast(t *testing.T) {

--- a/internal/correlate/correlate_test.go
+++ b/internal/correlate/correlate_test.go
@@ -1,0 +1,232 @@
+package correlate
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pgrundev/pgbot/internal/model"
+)
+
+func f64(v float64) *float64 { return &v }
+
+// ctxWith builds a minimal Context with the given unused indexes and a long
+// (non-cold) stats window.
+func ctxWith(unused []model.IndexStat, mut func(*model.Context)) *model.Context {
+	c := &model.Context{
+		Fingerprint: "abc123",
+		Indexes:     &model.Indexes{Unused: unused},
+	}
+	c.Window.StatsWindowDays = f64(45)
+	c.Window.StatsResetAt = &time.Time{}
+	if mut != nil {
+		mut(c)
+	}
+	return c
+}
+
+func find(r Report, name string) *IndexReport {
+	for i := range r.Indexes {
+		if r.Indexes[i].Index == name {
+			return &r.Indexes[i]
+		}
+	}
+	return nil
+}
+
+func TestSearchTerms_allFourCaseVariants(t *testing.T) {
+	terms := searchTermsFor([]string{"externalIdNormalized"})
+	want := []string{"externalIdNormalized", "external_id_normalized", "ExternalIdNormalized", "EXTERNAL_ID_NORMALIZED"}
+	for _, w := range want {
+		if !contains(terms, w) {
+			t.Errorf("search terms %v missing %q (all four cases must be emitted)", terms, w)
+		}
+	}
+}
+
+func TestSearchTerms_fromSnakeAndSingleWord(t *testing.T) {
+	// snake_case input must still yield camelCase and PascalCase.
+	terms := searchTermsFor([]string{"customer_id"})
+	for _, w := range []string{"customerId", "customer_id", "CustomerId", "CUSTOMER_ID"} {
+		if !contains(terms, w) {
+			t.Errorf("snake input: %v missing %q", terms, w)
+		}
+	}
+	// single word still gets a Pascal + CONSTANT form.
+	terms = searchTermsFor([]string{"status"})
+	for _, w := range []string{"status", "Status", "STATUS"} {
+		if !contains(terms, w) {
+			t.Errorf("single word: %v missing %q", terms, w)
+		}
+	}
+}
+
+func TestClassify_plainBtreeIsNeedsCodeCheck(t *testing.T) {
+	c := ctxWith([]model.IndexStat{
+		{Schema: "public", Table: "Job", Name: "Job_externalIdNormalized_idx", Method: "btree",
+			Columns: []string{"externalIdNormalized"}, Bytes: 41943040},
+	}, nil)
+	r := Build(c, nil)
+	ix := find(r, "Job_externalIdNormalized_idx")
+	if ix == nil || ix.Confidence != NeedsCodeCheck {
+		t.Fatalf("plain btree zero-scan must be needs_code_check, got %+v", ix)
+	}
+	if len(ix.SearchTerms) == 0 || ix.Instruction == "" || ix.IfFound == "" || ix.IfNotFound == "" {
+		t.Errorf("needs_code_check must carry search terms + instruction + if_found/if_not_found: %+v", ix)
+	}
+	if ix.DoNotDrop {
+		t.Errorf("needs_code_check must not set do_not_drop")
+	}
+}
+
+func TestInstruction_statesWhereVsSelect(t *testing.T) {
+	c := ctxWith([]model.IndexStat{
+		{Schema: "public", Table: "t", Name: "t_a_idx", Method: "btree", Columns: []string{"a"}, Bytes: 1 << 21},
+	}, nil)
+	ix := find(Build(c, nil), "t_a_idx")
+	if ix == nil {
+		t.Fatal("missing entry")
+	}
+	if !strings.Contains(ix.Instruction, "WHERE") || !strings.Contains(ix.Instruction, "SELECT") {
+		t.Errorf("instruction must state the WHERE-vs-SELECT distinction: %q", ix.Instruction)
+	}
+}
+
+func TestClassify_ginExpressionPartialAreInconclusive(t *testing.T) {
+	c := ctxWith([]model.IndexStat{
+		{Schema: "public", Table: "t", Name: "gin_idx", Method: "gin", Columns: []string{"tags"}, Bytes: 1 << 21},
+		{Schema: "public", Table: "t", Name: "expr_idx", Method: "btree", Expression: true, Bytes: 1 << 21},
+		{Schema: "public", Table: "t", Name: "partial_idx", Method: "btree", Columns: []string{"c"}, Partial: true, Bytes: 1 << 21},
+	}, nil)
+	r := Build(c, nil)
+	for _, name := range []string{"gin_idx", "expr_idx", "partial_idx"} {
+		ix := find(r, name)
+		if ix == nil || ix.Confidence != Inconclusive {
+			t.Errorf("%s must be inconclusive, got %+v", name, ix)
+			continue
+		}
+		if !ix.DoNotDrop || !strings.Contains(ix.Note, "Do not DROP INDEX on this evidence") {
+			t.Errorf("%s (inconclusive) must carry the do-not-drop wording: %+v", name, ix)
+		}
+		if len(ix.SearchTerms) != 0 {
+			t.Errorf("%s (inconclusive) must not emit search terms", name)
+		}
+	}
+}
+
+func TestInconclusive_neverPromotedByVerdict(t *testing.T) {
+	c := ctxWith([]model.IndexStat{
+		{Schema: "public", Table: "t", Name: "gin_idx", Method: "gin", Columns: []string{"tags"}, Bytes: 1 << 21},
+	}, nil)
+	// A "not found in code" verdict must NOT turn an inconclusive index actionable.
+	verdicts := map[string]PriorVerdict{
+		"public.gin_idx": {Verdict: "not_found_in_code", CheckedAt: time.Unix(1_700_000_000, 0)},
+	}
+	ix := find(Build(c, verdicts), "gin_idx")
+	if ix == nil || ix.Confidence != Inconclusive {
+		t.Fatalf("inconclusive must stay inconclusive even with a not_found verdict, got %+v", ix)
+	}
+	if !ix.DoNotDrop {
+		t.Errorf("still do-not-drop")
+	}
+}
+
+func TestColdWindow_demotesToInconclusive(t *testing.T) {
+	c := ctxWith([]model.IndexStat{
+		{Schema: "public", Table: "t", Name: "t_a_idx", Method: "btree", Columns: []string{"a"}, Bytes: 1 << 21},
+	}, func(c *model.Context) {
+		// A very recent stats reset makes the window cold.
+		c.Window.StatsWindowDays = f64(0.001)
+		age := int64(60) // 1 minute — below the 900s cold threshold
+		c.Window.WindowAgeSeconds = &age
+	})
+	r := Build(c, nil)
+	if !r.ColdWindow {
+		t.Fatal("expected cold window")
+	}
+	ix := find(r, "t_a_idx")
+	if ix == nil || ix.Confidence != Inconclusive {
+		t.Fatalf("cold window must demote to inconclusive, got %+v", ix)
+	}
+}
+
+func TestCatalogProven_noStatsCaveat_andRedundantWins(t *testing.T) {
+	c := ctxWith([]model.IndexStat{
+		{Schema: "public", Table: "t", Name: "dup_idx", Method: "btree", Columns: []string{"a"}, Bytes: 1 << 21},
+	}, func(c *model.Context) {
+		c.Indexes.Redundant = []model.RedundantIndex{
+			{Schema: "public", Table: "t", Name: "dup_idx", CoveredBy: "t_a_b_idx", Bytes: 1 << 21},
+		}
+	})
+	ix := find(Build(c, nil), "dup_idx")
+	if ix == nil || ix.Confidence != CatalogProven {
+		t.Fatalf("a zero-scan index that is also redundant must be catalog_proven, got %+v", ix)
+	}
+	if ix.DoNotDrop {
+		t.Errorf("catalog_proven must not be do-not-drop")
+	}
+	if len(ix.SearchTerms) != 0 {
+		t.Errorf("catalog_proven needs no code search")
+	}
+	if !strings.Contains(ix.Reason, "t_a_b_idx") {
+		t.Errorf("reason should name the covering index: %q", ix.Reason)
+	}
+}
+
+func TestInvalidIndex_isCatalogProven(t *testing.T) {
+	c := ctxWith(nil, func(c *model.Context) {
+		c.Schema = &model.SchemaFingerprint{Objects: []model.SchemaObject{
+			{Kind: "index", Identity: "public.orders.orders_bad_idx", Invalid: true},
+		}}
+	})
+	ix := find(Build(c, nil), "orders_bad_idx")
+	if ix == nil || ix.Confidence != CatalogProven {
+		t.Fatalf("invalid index must be catalog_proven, got %+v", ix)
+	}
+	if ix.Table != "orders" || ix.Schema != "public" {
+		t.Errorf("identity should parse to schema/table: %+v", ix)
+	}
+}
+
+func TestVerdict_strengthensNeedsCodeCheck(t *testing.T) {
+	c := ctxWith([]model.IndexStat{
+		{Schema: "public", Table: "t", Name: "t_a_idx", Method: "btree", Columns: []string{"a"}, Bytes: 1 << 21},
+	}, nil)
+	verdicts := map[string]PriorVerdict{
+		"public.t_a_idx": {Verdict: "not_found_in_code", RepoRef: "abc123", CheckedAt: time.Unix(1_700_000_000, 0), StatsWindowDays: f64(12)},
+	}
+	ix := find(Build(c, verdicts), "t_a_idx")
+	if ix == nil || ix.PriorVerdict == nil {
+		t.Fatalf("prior verdict should be attached, got %+v", ix)
+	}
+	if !strings.Contains(ix.Note, "strengthened") || !strings.Contains(ix.Note, "12d") || !strings.Contains(ix.Note, "45d") {
+		t.Errorf("note should show window growth 12d -> 45d: %q", ix.Note)
+	}
+}
+
+func TestSort_catalogFirstInconclusiveLast(t *testing.T) {
+	c := ctxWith([]model.IndexStat{
+		{Schema: "public", Table: "t", Name: "gin_idx", Method: "gin", Columns: []string{"tags"}, Bytes: 1 << 21},
+		{Schema: "public", Table: "t", Name: "plain_idx", Method: "btree", Columns: []string{"a"}, Bytes: 1 << 21},
+		{Schema: "public", Table: "t", Name: "dup_idx", Method: "btree", Columns: []string{"b"}, Bytes: 1 << 21},
+	}, func(c *model.Context) {
+		c.Indexes.Redundant = []model.RedundantIndex{{Schema: "public", Table: "t", Name: "dup_idx", CoveredBy: "x"}}
+	})
+	r := Build(c, nil)
+	if len(r.Indexes) != 3 {
+		t.Fatalf("want 3, got %d", len(r.Indexes))
+	}
+	if r.Indexes[0].Confidence != CatalogProven || r.Indexes[len(r.Indexes)-1].Confidence != Inconclusive {
+		t.Errorf("order should be catalog_proven..inconclusive, got %v/%v",
+			r.Indexes[0].Confidence, r.Indexes[len(r.Indexes)-1].Confidence)
+	}
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/findings/findings.go
+++ b/internal/findings/findings.go
@@ -270,6 +270,24 @@ func impact(dim string, score float64, estimate, basis string) model.Impact {
 	return model.Impact{Score: score, Dimension: dim, Estimate: estimate, Basis: basis}
 }
 
+// safety, prohibition, and precondition build the structured guards for a finding
+// whose remediation involves a destructive or irreversible action. Emitted here,
+// in code — never left to a summarizing model — so they are guaranteed in --json,
+// SARIF, and MCP, and asserted by model-free tests keyed on guard ID.
+func safety(guards ...model.SafetyGuard) *model.Safety {
+	return &model.Safety{BlockingCaveats: guards}
+}
+
+// prohibition: never do Action while the finding's state holds (Verify is nil).
+func prohibition(id, action, text string) model.SafetyGuard {
+	return model.SafetyGuard{ID: id, Kind: model.GuardProhibition, Action: action, Text: text}
+}
+
+// precondition: Action is permitted only after the Verify check passes.
+func precondition(id, action, text, verify string) model.SafetyGuard {
+	return model.SafetyGuard{ID: id, Kind: model.GuardPrecondition, Action: action, Text: text, Verify: &verify}
+}
+
 // sizeScore maps a byte count onto 0..100 on a log scale: ~1 MiB scores near 0,
 // ~100 GiB scores near 100. Storage wins are naturally logarithmic — the gap
 // between 8 KB and 12 GB should dwarf the gap between 12 GB and 20 GB.
@@ -350,10 +368,15 @@ func invalidIndexes(c *model.Context, add func(model.Finding)) {
 	var caveats []string
 	conf := 1.0
 	sev := model.SeverityCritical
+	guard := precondition("invalid_index.no_build_running", model.ActionDropIndex,
+		"An invalid index left by a stopped build can be dropped and rebuilt — but a plain DROP INDEX takes an ACCESS EXCLUSIVE lock.",
+		"no CREATE INDEX build is running, then DROP INDEX CONCURRENTLY and rebuild")
 	if createIndexInProgress(c) {
 		caveats = append(caveats, "a CREATE INDEX CONCURRENTLY is currently running (see progress) — an index invalid because it's still building is normal; only a build that has stopped needs the drop-and-rebuild")
 		conf = 0.5
 		sev = model.SeverityWarn
+		guard = prohibition("invalid_index.build_in_progress", model.ActionDropIndex,
+			"A CREATE INDEX CONCURRENTLY is still building this index — dropping it now kills a build seconds before it goes valid.")
 	}
 	add(model.Finding{
 		ID: "index_invalid", Severity: sev,
@@ -367,6 +390,7 @@ func invalidIndexes(c *model.Context, add func(model.Finding)) {
 			"pg_index.indisvalid = false"),
 		Confidence: conf,
 		Caveats:    caveats,
+		Safety:     safety(guard),
 	})
 }
 
@@ -483,6 +507,9 @@ func unusedIndexes(c *model.Context, add func(model.Finding), tun Tunables) {
 		Impact:      impact(model.DimStorage, found[0].score, estimate, basis),
 		Confidence:  confidence,
 		Caveats:     caveats,
+		Safety: safety(precondition("unused_index.per_node", model.ActionDropIndex,
+			"These are zero scans in ONE window on THIS node — a rarely-run or replica-only query still needs the index.",
+			"the index is unused on EVERY node in the cluster (including replicas) and by any periodic/off-window job, then DROP INDEX CONCURRENTLY")),
 	})
 }
 
@@ -563,6 +590,9 @@ func redundantIndexes(c *model.Context, add func(model.Finding)) {
 		Impact:      impact(model.DimStorage, sizeScore(total), "≈"+humanBytes(total)+" reclaimable", fmt.Sprintf("%d prefix-redundant indexes (indkey/indclass containment)", len(ev))),
 		Confidence:  0.75,
 		Caveats:     caveats,
+		Safety: safety(precondition("redundant_index.covering_equivalent", model.ActionDropIndex,
+			"A leading-prefix match can still miss a difference the covering index does not cover (extra INCLUDE columns, a different opclass or collation), and index choice is per-node.",
+			"the covering index has the same INCLUDE columns, opclass, and collation, and is the one used on any replicas, then DROP INDEX CONCURRENTLY")),
 	})
 }
 
@@ -1116,6 +1146,8 @@ func txidWraparound(c *model.Context, add func(model.Finding)) {
 			fmt.Sprintf("age %s / 2.1B", human(age)),
 			"max(age(datfrozenxid)) across databases"),
 		Confidence: 1.0,
+		Safety: safety(prohibition("wraparound.no_vacuum_full", model.ActionVacuumFull,
+			"VACUUM FULL / CLUSTER / pg_repack take ACCESS EXCLUSIVE and CONSUME transaction IDs — exactly what is running out. Use VACUUM (FREEZE) only.")),
 	})
 }
 
@@ -1159,6 +1191,9 @@ func sequenceExhaustion(c *model.Context, add func(model.Finding)) {
 		Remediation: "Migrate the owning column to bigint (ALTER TABLE … ALTER COLUMN … TYPE bigint — plan for the table rewrite). If the column is already bigint, exhaustion is astronomically far off.",
 		Impact:      impact(model.DimRisk, worst*100, fmt.Sprintf("%.0f%% of range used", worst*100), "last_value / min(max_value, column type max)"),
 		Confidence:  0.9,
+		Safety: safety(precondition("narrow_column.table_rewrite", model.ActionAlterColumnType,
+			"ALTER ... TYPE bigint rewrites the whole table under an ACCESS EXCLUSIVE lock.",
+			"you have planned for the lock/downtime (or use a phased add-column/backfill/swap), and widen any int4 foreign-key columns that reference it in the same change")),
 	})
 }
 
@@ -1196,6 +1231,9 @@ func int4IdentityColumn(c *model.Context, add func(model.Finding)) {
 		Remediation: "Define identity/serial columns as bigint. To widen an existing one: ALTER TABLE … ALTER COLUMN … TYPE bigint (a table rewrite — plan for it, and widen any int4 foreign-key columns that reference it in the same change).",
 		Impact:      impact(model.DimRisk, 55, fmt.Sprintf("%d column(s)", len(ev)), "column type of sequence-backed columns (pg_attribute)"),
 		Confidence:  0.95,
+		Safety: safety(precondition("narrow_column.table_rewrite", model.ActionAlterColumnType,
+			"ALTER ... TYPE bigint rewrites the whole table under an ACCESS EXCLUSIVE lock.",
+			"you have planned for the lock/downtime (or use a phased add-column/backfill/swap), and widen any int4 foreign-key columns that reference it in the same change")),
 	})
 }
 
@@ -1222,6 +1260,8 @@ func mxidWraparound(c *model.Context, add func(model.Finding)) {
 			fmt.Sprintf("mxid age %s / 2.1B", human(age)),
 			"max(mxid_age(datminmxid)) across databases"),
 		Confidence: 1.0,
+		Safety: safety(prohibition("mxid_wraparound.no_vacuum_full", model.ActionVacuumFull,
+			"VACUUM FULL / CLUSTER / pg_repack take ACCESS EXCLUSIVE and make the wraparound race worse, not better. Use VACUUM (FREEZE) only to advance datminmxid.")),
 	})
 }
 
@@ -1471,6 +1511,12 @@ func checksumFindings(c *model.Context, add func(model.Finding)) {
 			Caveats:    []string{"Do NOT VACUUM FULL or REINDEX the affected relation — rewriting the pages destroys the evidence and can propagate the damage. Preserve state, then restore from backup."},
 			Impact:     impact(model.DimRisk, 96, fmt.Sprintf("%d checksum failures", total), "pg_stat_database.checksum_failures > 0"),
 			Confidence: 1.0,
+			Safety: safety(
+				prohibition("checksum.no_vacuum_full", model.ActionVacuumFull,
+					"Rewriting the pages (VACUUM FULL / CLUSTER / pg_repack) destroys the evidence and can turn a recoverable incident into an unrecoverable one. Preserve state, then restore from a known-good backup."),
+				prohibition("checksum.no_reindex", model.ActionReindex,
+					"REINDEX rewrites index pages over corrupt data — it destroys evidence and can propagate the damage. Preserve state, then restore from a known-good backup."),
+			),
 		})
 	}
 	if settingParam(c, "ignore_checksum_failure") == "on" {
@@ -1687,9 +1733,11 @@ func replicationSlotRisk(c *model.Context, add func(model.Finding)) {
 			Title:       fmt.Sprintf("Inactive replication slot %q pinning %s of WAL", s.Name, humanBytes(s.RetainedBytes)),
 			Detail:      "An inactive replication slot holds back WAL removal from its restart point. The retained WAL grows until the slot's consumer reconnects or the slot is dropped — a classic way to fill the data disk and take the primary down.",
 			Evidence:    ev,
-			Remediation: fmt.Sprintf("If the standby/subscriber is gone for good, drop it: SELECT pg_drop_replication_slot('%s'). If it should be connected, restart its consumer. Set max_slot_wal_keep_size to cap the retention.", s.Name),
+			Remediation: fmt.Sprintf("First find the slot's consumer: if it should be connected, restart it, and set max_slot_wal_keep_size to cap retention. Only once you've confirmed no standby or subscriber still depends on it, drop it: SELECT pg_drop_replication_slot('%s').", s.Name),
 			Impact:      impact(model.DimRisk, score, humanBytes(s.RetainedBytes)+" WAL retained", "pg_replication_slots"),
 			Confidence:  0.9,
+			Safety: safety(prohibition("replication_slot.live_consumer", model.ActionDropReplicationSlot,
+				"Dropping a slot a live standby or logical subscriber still depends on permanently breaks its replication and forces a full resync. Confirm the consumer is truly gone before pg_drop_replication_slot.")),
 		})
 	}
 }

--- a/internal/findings/safety_test.go
+++ b/internal/findings/safety_test.go
@@ -1,0 +1,134 @@
+package findings
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/pgrundev/pgbot/internal/model"
+)
+
+func warmWindow() model.Window {
+	age := int64(45 * 24 * 3600) // 45 days — well past the cold-window threshold
+	return model.Window{WindowAgeSeconds: &age}
+}
+
+func guardByID(f *model.Finding, id string) *model.SafetyGuard {
+	if f == nil || f.Safety == nil {
+		return nil
+	}
+	for i := range f.Safety.BlockingCaveats {
+		if f.Safety.BlockingCaveats[i].ID == id {
+			return &f.Safety.BlockingCaveats[i]
+		}
+	}
+	return nil
+}
+
+// TestSafety_perDestructiveFinding is model-free: each destructive finding must
+// carry its structured guard, keyed on a stable ID (never text), with the right
+// Kind/Action and a Verify present iff it's a precondition.
+func TestSafety_perDestructiveFinding(t *testing.T) {
+	cases := []struct {
+		name      string
+		ctx       *model.Context
+		findingID string
+		guardID   string
+		action    string
+		kind      string
+	}{
+		{"unused_indexes",
+			&model.Context{Window: warmWindow(), Indexes: &model.Indexes{Unused: []model.IndexStat{{Schema: "public", Table: "t", Name: "i", Bytes: 50 << 20, Method: "btree", Columns: []string{"a"}}}}},
+			"unused_indexes", "unused_index.per_node", model.ActionDropIndex, model.GuardPrecondition},
+		{"redundant_indexes",
+			&model.Context{Indexes: &model.Indexes{Redundant: []model.RedundantIndex{{Schema: "public", Table: "t", Name: "i", CoveredBy: "j", Bytes: 1 << 20}}}},
+			"redundant_indexes", "redundant_index.covering_equivalent", model.ActionDropIndex, model.GuardPrecondition},
+		{"index_invalid",
+			&model.Context{Schema: &model.SchemaFingerprint{Objects: []model.SchemaObject{{Kind: "index", Identity: "public.t.i", Invalid: true}}}},
+			"index_invalid", "invalid_index.no_build_running", model.ActionDropIndex, model.GuardPrecondition},
+		{"checksum_failures",
+			&model.Context{Checksums: &model.Checksums{Failures: []model.ChecksumFailure{{Database: "d", Count: 2}}}},
+			"checksum_failures", "checksum.no_vacuum_full", model.ActionVacuumFull, model.GuardProhibition},
+		{"txid_wraparound",
+			&model.Context{Limits: &model.Limits{MaxXIDAge: xidWraparoundWarn + 1}},
+			"txid_wraparound", "wraparound.no_vacuum_full", model.ActionVacuumFull, model.GuardProhibition},
+		{"mxid_wraparound",
+			&model.Context{Limits: &model.Limits{MaxMXIDAge: xidWraparoundWarn + 1}},
+			"mxid_wraparound", "mxid_wraparound.no_vacuum_full", model.ActionVacuumFull, model.GuardProhibition},
+		{"sequence_exhaustion",
+			&model.Context{Sequences: &model.Sequences{Items: []model.SequenceUsage{{Schema: "public", Name: "s", LastValue: 2_000_000_000, Ceiling: 2_147_483_647, PctUsed: 0.93}}}},
+			"sequence_exhaustion", "narrow_column.table_rewrite", model.ActionAlterColumnType, model.GuardPrecondition},
+		{"int4_identity_column",
+			&model.Context{Sequences: &model.Sequences{NarrowIdentity: []model.NarrowIdentityColumn{{Schema: "public", Table: "t", Column: "id", Type: "int4"}}}},
+			"int4_identity_column", "narrow_column.table_rewrite", model.ActionAlterColumnType, model.GuardPrecondition},
+		{"replication_slot_inactive",
+			&model.Context{Replication: &model.Replication{Slots: []model.ReplicationSlot{{Name: "s", Type: "logical", Active: false, RetainedBytes: 2 << 30}}}},
+			"replication_slot_inactive", "replication_slot.live_consumer", model.ActionDropReplicationSlot, model.GuardProhibition},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := has(Compute(tc.ctx), tc.findingID)
+			if f == nil {
+				t.Fatalf("finding %s did not fire from its fixture", tc.findingID)
+			}
+			g := guardByID(f, tc.guardID)
+			if g == nil {
+				t.Fatalf("finding %s is missing safety guard %q; Safety=%+v", tc.findingID, tc.guardID, f.Safety)
+			}
+			if g.Action != tc.action {
+				t.Errorf("guard action = %q, want %q", g.Action, tc.action)
+			}
+			if g.Kind != tc.kind {
+				t.Errorf("guard kind = %q, want %q", g.Kind, tc.kind)
+			}
+			if tc.kind == model.GuardPrecondition && g.Verify == nil {
+				t.Errorf("a precondition guard must state what clears it (Verify)")
+			}
+			if tc.kind == model.GuardProhibition && g.Verify != nil {
+				t.Errorf("a prohibition guard must have nil Verify (nothing clears it while the state holds)")
+			}
+		})
+	}
+}
+
+// destructiveRemediationRE matches a remediation that tells the user to run a
+// destructive or irreversible statement. Kept to the verbs that actually appear in
+// pgbot remediations to avoid flagging innocuous text.
+var destructiveRemediationRE = regexp.MustCompile(
+	`(?i)\bDROP\s+INDEX\b|\bVACUUM\s+FULL\b|\bREINDEX\b|\bDROP\s+REPLICATION\s+SLOT\b|pg_drop_replication_slot|\bALTER\b[^.]{0,40}\bTYPE\b|\bDROP\s+TABLE\b|\bDROP\s+COLUMN\b|\bTRUNCATE\b`)
+
+// TestSafety_regressionGuard (Step 8) is the backstop: any finding whose
+// remediation suggests a destructive action MUST declare a Safety guard. It runs
+// over a context that triggers every destructive finding, so deleting a guard — or
+// adding a new destructive finding to this fixture without one — fails the build.
+func TestSafety_regressionGuard(t *testing.T) {
+	c := &model.Context{
+		Window: warmWindow(),
+		Indexes: &model.Indexes{
+			Unused:    []model.IndexStat{{Schema: "public", Table: "t", Name: "ui", Bytes: 50 << 20, Method: "btree", Columns: []string{"a"}}},
+			Redundant: []model.RedundantIndex{{Schema: "public", Table: "t", Name: "ri", CoveredBy: "j", Bytes: 1 << 20}},
+		},
+		Schema:    &model.SchemaFingerprint{Objects: []model.SchemaObject{{Kind: "index", Identity: "public.t.bad", Invalid: true}}},
+		Checksums: &model.Checksums{Failures: []model.ChecksumFailure{{Database: "d", Count: 3}}},
+		Limits:    &model.Limits{MaxXIDAge: xidWraparoundWarn + 1, MaxMXIDAge: xidWraparoundWarn + 1},
+		Sequences: &model.Sequences{
+			Items:          []model.SequenceUsage{{Schema: "public", Name: "s", LastValue: 2_000_000_000, Ceiling: 2_147_483_647, PctUsed: 0.93}},
+			NarrowIdentity: []model.NarrowIdentityColumn{{Schema: "public", Table: "t", Column: "id", Type: "int4"}},
+		},
+		Replication: &model.Replication{Slots: []model.ReplicationSlot{{Name: "s", Type: "logical", Active: false, RetainedBytes: 2 << 30}}},
+	}
+	destructive := 0
+	for _, f := range Compute(c) {
+		if !destructiveRemediationRE.MatchString(f.Remediation) {
+			continue
+		}
+		destructive++
+		if f.Safety == nil || len(f.Safety.BlockingCaveats) == 0 {
+			t.Errorf("finding %q has a destructive remediation but declares no Safety guard.\n  remediation: %q", f.ID, f.Remediation)
+		}
+	}
+	// Guard against the guard silently covering nothing (e.g. the fixture stops
+	// triggering the destructive findings).
+	if destructive < 6 {
+		t.Fatalf("expected ≥6 destructive-remediation findings in the fixture, saw %d — extend the fixture so the regression check has teeth", destructive)
+	}
+}

--- a/internal/model/compat_test.go
+++ b/internal/model/compat_test.go
@@ -25,11 +25,12 @@ type v100Consumer struct {
 	} `json:"findings"`
 }
 
-// TestV100ConsumerParsesV110 asserts a v1.0.0-shaped consumer still parses the
-// current (1.1.0) output: additive-only means the fields it depends on are intact
-// and the new keys are simply ignored.
-func TestV100ConsumerParsesV110(t *testing.T) {
-	// A realistic 1.1.0 Context carrying every additive surface.
+// TestV100ConsumerParsesCurrent asserts a v1.0.0-shaped consumer still parses the
+// current output: additive-only means the fields it depends on are intact and the
+// newer keys (events, wait_profile, and the 1.2.0 IndexStat columns/method) are
+// simply ignored.
+func TestV100ConsumerParsesCurrent(t *testing.T) {
+	// A realistic Context carrying every additive surface, including 1.2.0's.
 	reset := time.Now().UTC()
 	age := int64(4 * 3600)
 	c := &Context{
@@ -39,6 +40,10 @@ func TestV100ConsumerParsesV110(t *testing.T) {
 		Window:        Window{WindowAgeSeconds: &age, StatsResetAt: &reset},
 		Events:        []Event{{Kind: "config.changed", Object: "work_mem", Confidence: 0.5}},
 		WaitProfile:   &WaitProfile{Available: true, Samples: 50, Buckets: []WaitBucket{{Type: "Lock", Share: 0.6}}},
+		Indexes: &Indexes{Unused: []IndexStat{{
+			Schema: "public", Table: "a", Name: "a_idx", Bytes: 1 << 20,
+			Columns: []string{"customer_id"}, Method: "btree", Unique: false, Primary: false,
+		}}},
 		Findings: []Finding{{
 			ID: "unused_indexes", Severity: SeverityWarn, Title: "3 unused indexes", Detail: "…",
 			Evidence: []string{"public.a.idx"}, Remediation: "drop it",
@@ -53,10 +58,10 @@ func TestV100ConsumerParsesV110(t *testing.T) {
 	}
 	var got v100Consumer
 	if err := json.Unmarshal(blob, &got); err != nil {
-		t.Fatalf("a v1.0.0 consumer must parse v1.1.0 output, got: %v", err)
+		t.Fatalf("a v1.0.0 consumer must parse current output, got: %v", err)
 	}
-	if got.SchemaVersion != "1.1.0" {
-		t.Errorf("schema_version = %q, want 1.1.0", got.SchemaVersion)
+	if got.SchemaVersion != SchemaVersion {
+		t.Errorf("schema_version = %q, want %q", got.SchemaVersion, SchemaVersion)
 	}
 	if got.Server.Database != "production" || got.Server.VersionNum != 170002 {
 		t.Errorf("server fields did not survive: %+v", got.Server)

--- a/internal/model/context.go
+++ b/internal/model/context.go
@@ -563,6 +563,43 @@ type Settings struct {
 
 // Finding is deterministic, rule-based analysis computed in Go — never by the
 // LLM. The model layer explains and prioritises Findings; it does not create them.
+// SafetyGuard is one machine-actionable guard against a destructive action. An
+// agent about to run Action matches it directly; ID is the stable key tests and
+// consumers branch on (never the Text — wording can improve without breaking a
+// consumer). Kind separates a prohibition (never do this while the state holds;
+// Verify is nil) from a precondition (permitted only after the Verify check passes).
+type SafetyGuard struct {
+	ID     string  `json:"id"`
+	Kind   string  `json:"kind"`   // GuardProhibition | GuardPrecondition
+	Action string  `json:"action"` // one of the Action* constants below
+	Text   string  `json:"text"`   // the sentence a human reads — never the source of truth for machines
+	Verify *string `json:"verify"` // what clears a precondition; nil for a prohibition
+}
+
+// Safety is the structured, guaranteed carrier for a finding's destructive-action
+// guards — deterministic, never model-generated, present in --json / SARIF / MCP
+// and asserted by model-free tests. A non-empty BlockingCaveats IS the "this
+// finding guards a destructive action" signal; there is no separate boolean.
+type Safety struct {
+	BlockingCaveats []SafetyGuard `json:"blocking_caveats"`
+}
+
+// Guard kinds.
+const (
+	GuardProhibition  = "prohibition"  // never do this while the state holds
+	GuardPrecondition = "precondition" // permitted only after Verify passes
+)
+
+// Destructive-action vocabulary — the Action an agent matches a guard on. Defined
+// in one place so a consumer and pgbot agree on the exact strings.
+const (
+	ActionDropIndex           = "DROP INDEX"
+	ActionVacuumFull          = "VACUUM FULL"
+	ActionReindex             = "REINDEX"
+	ActionDropReplicationSlot = "DROP REPLICATION SLOT"
+	ActionAlterColumnType     = "ALTER TABLE ... TYPE"
+)
+
 type Finding struct {
 	ID string `json:"id"` // stable slug, e.g. "unused_indexes"
 	// Object is a STABLE, human-writable identity for suppression keying (B2-0):
@@ -590,6 +627,14 @@ type Finding struct {
 	Confidence float64  `json:"confidence"` // 0.0–1.0; below 0.5 renders as "possible", not an assertion
 	Caveats    []string `json:"caveats,omitempty"`
 	Related    []string `json:"related,omitempty"` // ids of findings that travel with this one (rendered adjacently)
+	// Safety carries the DETERMINISTIC, machine-actionable guards against a
+	// destructive or irreversible action (DROP INDEX, VACUUM FULL, dropping a slot,
+	// a table rewrite). Unlike Caveats (free-form context a summarizing model may
+	// reword away), these are guaranteed present in --json, SARIF, and the MCP
+	// payloads, and asserted by model-free tests keyed on guard ID. Text rendering
+	// is a view over this field, never its origin. nil when the finding guards no
+	// destructive action.
+	Safety *Safety `json:"safety,omitempty"`
 	// Suppression state, set by a matching [[ignore]] rule (B2-2). A suppressed
 	// finding is never DELETED — it stays in --json (so an agent can explain why
 	// it isn't reporting it) and does not affect the exit code. A suppressed

--- a/internal/model/context.go
+++ b/internal/model/context.go
@@ -561,8 +561,6 @@ type Settings struct {
 	Params    map[string]string `json:"params,omitempty"` // tuning-relevant params (display values), always present
 }
 
-// Finding is deterministic, rule-based analysis computed in Go — never by the
-// LLM. The model layer explains and prioritises Findings; it does not create them.
 // SafetyGuard is one machine-actionable guard against a destructive action. An
 // agent about to run Action matches it directly; ID is the stable key tests and
 // consumers branch on (never the Text — wording can improve without breaking a
@@ -600,6 +598,8 @@ const (
 	ActionAlterColumnType     = "ALTER TABLE ... TYPE"
 )
 
+// Finding is deterministic, rule-based analysis computed in Go — never by the
+// LLM. The model layer explains and prioritises Findings; it does not create them.
 type Finding struct {
 	ID string `json:"id"` // stable slug, e.g. "unused_indexes"
 	// Object is a STABLE, human-writable identity for suppression keying (B2-0):

--- a/internal/model/context.go
+++ b/internal/model/context.go
@@ -377,14 +377,18 @@ type RedundantIndex struct {
 }
 
 type IndexStat struct {
-	Schema     string `json:"schema"`
-	Table      string `json:"table"`
-	Name       string `json:"index"`
-	Scans      int64  `json:"scans"`
-	Bytes      int64  `json:"bytes"`
-	Definition string `json:"definition,omitempty"`
-	Partial    bool   `json:"partial,omitempty"`    // has a WHERE predicate — may serve a narrow but critical path
-	Expression bool   `json:"expression,omitempty"` // indexes an expression, not bare columns
+	Schema     string   `json:"schema"`
+	Table      string   `json:"table"`
+	Name       string   `json:"index"`
+	Scans      int64    `json:"scans"`
+	Bytes      int64    `json:"bytes"`
+	Definition string   `json:"definition,omitempty"`
+	Columns    []string `json:"columns,omitempty"`    // bare key columns (empty for a pure-expression index) — feeds code correlation
+	Method     string   `json:"method,omitempty"`     // access method: btree, gin, gist, brin, hash, spgist
+	Unique     bool     `json:"unique,omitempty"`     // enforces uniqueness
+	Primary    bool     `json:"primary,omitempty"`    // the table's primary-key index
+	Partial    bool     `json:"partial,omitempty"`    // has a WHERE predicate — may serve a narrow but critical path
+	Expression bool     `json:"expression,omitempty"` // indexes an expression, not bare columns
 }
 
 // WAL is pg_stat_wal (PG14+), double-sampled.

--- a/internal/model/schema_version.go
+++ b/internal/model/schema_version.go
@@ -7,4 +7,7 @@ package model
 // 1.1.0 (Phase 1): additive only — Events, WaitProfile, the T2 window/suppression
 // fields, and Finding.Impact/Confidence/Caveats. No v1.0.0 field changed type or
 // meaning, so a 1.0.0 consumer still parses 1.1.0 output (it ignores the new keys).
-const SchemaVersion = "1.1.0"
+//
+// 1.2.0: additive only — IndexStat gains columns/method/unique/primary (feeding
+// index/code correlation). A 1.1.0 consumer still parses 1.2.0 output.
+const SchemaVersion = "1.2.0"

--- a/internal/render/dashboard.go
+++ b/internal/render/dashboard.go
@@ -159,6 +159,23 @@ func renderSafetyGuards(b *strings.Builder, st styler, f model.Finding, width in
 	}
 }
 
+// safetyText renders a finding's destructive-action guards as one plain-text line,
+// for the text-message surfaces (SARIF, JUnit). Empty when there are no guards.
+func safetyText(f *model.Finding) string {
+	if f == nil || f.Safety == nil || len(f.Safety.BlockingCaveats) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, g := range f.Safety.BlockingCaveats {
+		s := "SAFETY [" + g.Action + "]: " + g.Text
+		if g.Verify != nil {
+			s += " Only after: " + *g.Verify
+		}
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, " ")
+}
+
 // computeHealthScore is a coarse 0–100 grade: full marks minus a penalty per
 // finding by severity. It's an at-a-glance indicator, not a precise metric.
 // suppReason renders an ignore rule's reason, or a stand-in when none was given.

--- a/internal/render/dashboard.go
+++ b/internal/render/dashboard.go
@@ -98,6 +98,9 @@ func renderGrouped(b *strings.Builder, st styler, c *model.Context, width int) {
 			if f.Suppressed { // a rendered-but-suppressed critical
 				fmt.Fprintf(b, "  %s\n", st.dim("suppressed by config: "+suppReason(f)))
 			}
+			// A destructive-action guard travels even in the compact view — a
+			// prohibition or precondition is exactly what must not be dropped for space.
+			renderSafetyGuards(b, st, f, width, "  ")
 		}
 		fmt.Fprintln(b)
 	}
@@ -130,6 +133,30 @@ func renderGrouped(b *strings.Builder, st styler, c *model.Context, width int) {
 
 	fmt.Fprintln(b, st.dim("Details: pgbot inspect --full   ·   Machine-readable: --json"))
 	fmt.Fprintln(b, st.dim(`Ask it: pgbot ask "what's wrong?"`))
+}
+
+// renderSafetyGuards prints a finding's structured destructive-action guards
+// compactly — a prohibition as "do NOT <ACTION>", a precondition as "before
+// <ACTION>, confirm: <verify>". Guaranteed from the structured field, never
+// summary prose, and shared by the grouped view and the --full findings list.
+func renderSafetyGuards(b *strings.Builder, st styler, f model.Finding, width int, indent string) {
+	if f.Safety == nil {
+		return
+	}
+	for _, g := range f.Safety.BlockingCaveats {
+		var line string
+		switch {
+		case g.Kind == model.GuardProhibition:
+			line = "⚠ do NOT " + g.Action + " — " + g.Text
+		case g.Verify != nil:
+			line = "⚠ before " + g.Action + ", confirm: " + *g.Verify
+		default:
+			line = "⚠ " + g.Action + ": " + g.Text
+		}
+		for _, l := range wrapText(line, width-len(indent)-2) {
+			fmt.Fprintf(b, "%s%s\n", indent, st.warn(l))
+		}
+	}
 }
 
 // computeHealthScore is a coarse 0–100 grade: full marks minus a penalty per

--- a/internal/render/junit.go
+++ b/internal/render/junit.go
@@ -28,10 +28,14 @@ func JUnit(w io.Writer, c *model.Context, failOn string) error {
 		case f.Suppressed:
 			tc.Skipped = &junitSkipped{Message: "suppressed by config: " + f.SuppressionReason}
 		case failOn != "none" && junitRank(f.Severity) >= threshold:
+			text := strings.TrimSpace(f.Detail + "\n" + f.Remediation)
+			if s := safetyText(f); s != "" {
+				text = strings.TrimSpace(text + "\n" + s)
+			}
 			tc.Failure = &junitFailure{
 				Message: f.Title,
 				Type:    f.Severity,
-				Text:    strings.TrimSpace(f.Detail + "\n" + f.Remediation),
+				Text:    text,
 			}
 			suite.Failures++
 		}

--- a/internal/render/prometheus.go
+++ b/internal/render/prometheus.go
@@ -27,7 +27,7 @@ func Prometheus(w io.Writer, c *model.Context) error {
 // and make promtool (and the textfile collector) reject the file.
 func PrometheusAll(w io.Writer, contexts []*model.Context) error {
 	finding := &promFamily{name: "pgbot_finding", typ: "gauge",
-		help: `A pgbot finding (1 = present). suppressed="true" means muted by .pgbot.toml.`}
+		help: `A pgbot finding (1 = present). suppressed="true" means muted by .pgbot.toml; destructive="true" means it carries a safety guard against a destructive action.`}
 	total := &promFamily{name: "pgbot_findings_total", typ: "gauge",
 		help: "Active (unsuppressed) findings by severity."}
 
@@ -54,8 +54,9 @@ func PrometheusAll(w io.Writer, contexts []*model.Context) error {
 			if !f.Suppressed {
 				counts[f.Severity]++
 			}
-			finding.add(fmt.Sprintf("pgbot_finding{database=%q,id=%q,severity=%q,dimension=%q,object=%q,suppressed=%q} 1",
-				db, esc(f.ID), esc(f.Severity), esc(f.Impact.Dimension), esc(f.Object), boolLabel(f.Suppressed)))
+			finding.add(fmt.Sprintf("pgbot_finding{database=%q,id=%q,severity=%q,dimension=%q,object=%q,suppressed=%q,destructive=%q} 1",
+				db, esc(f.ID), esc(f.Severity), esc(f.Impact.Dimension), esc(f.Object), boolLabel(f.Suppressed),
+				boolLabel(f.Safety != nil && len(f.Safety.BlockingCaveats) > 0)))
 		}
 		for _, sev := range []string{"critical", "warn", "info"} {
 			total.add(fmt.Sprintf("pgbot_findings_total{database=%q,severity=%q} %d", db, sev, counts[sev]))

--- a/internal/render/safety_render_test.go
+++ b/internal/render/safety_render_test.go
@@ -1,0 +1,79 @@
+package render
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/pgrundev/pgbot/internal/model"
+)
+
+func ptr(s string) *string { return &s }
+
+// a finding carrying a precondition guard (DROP INDEX) and a prohibition guard.
+func guardedContext() *model.Context {
+	return &model.Context{
+		SchemaVersion: model.SchemaVersion,
+		Findings: []model.Finding{
+			{
+				ID: "unused_indexes", Severity: model.SeverityWarn, Title: "1 unused index",
+				Remediation: "Drop with DROP INDEX CONCURRENTLY after confirming the caveats.",
+				Safety: &model.Safety{BlockingCaveats: []model.SafetyGuard{
+					{ID: "unused_index.per_node", Kind: model.GuardPrecondition, Action: model.ActionDropIndex,
+						Text: "zero scans on this node only", Verify: ptr("the index is unused on every replica")},
+				}},
+			},
+			{
+				ID: "checksum_failures", Severity: model.SeverityCritical, Title: "corruption",
+				Remediation: "Restore from backup.",
+				Safety: &model.Safety{BlockingCaveats: []model.SafetyGuard{
+					{ID: "checksum.no_vacuum_full", Kind: model.GuardProhibition, Action: model.ActionVacuumFull,
+						Text: "rewriting pages destroys the evidence"},
+				}},
+			},
+		},
+	}
+}
+
+// Step 6: the structured guard must survive into --json, keyed on its stable ID.
+func TestSafety_inJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := JSON(&buf, guardedContext()); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{`"blocking_caveats"`, `"unused_index.per_node"`, `"checksum.no_vacuum_full"`, `"DROP INDEX"`, `"VACUUM FULL"`, `"precondition"`, `"prohibition"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--json output is missing %s — the structured guard was dropped", want)
+		}
+	}
+}
+
+// Step 6: SARIF (GitHub Security tab) must carry the guard text, not just the
+// remediation — the original bug was that it silently dropped every caveat.
+func TestSafety_inSARIF(t *testing.T) {
+	var buf bytes.Buffer
+	if err := SARIF(&buf, guardedContext()); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{"DROP INDEX", "the index is unused on every replica", "VACUUM FULL", "rewriting pages destroys the evidence"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("SARIF output is missing %q — a destructive guard was dropped", want)
+		}
+	}
+}
+
+// Step 7 guard: the grouped (default) and full terminal views render the guard.
+func TestSafety_inTerminal(t *testing.T) {
+	for _, full := range []bool{false, true} {
+		var buf bytes.Buffer
+		if err := Terminal(&buf, guardedContext(), Options{Full: full, Width: 100}); err != nil {
+			t.Fatal(err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "DROP INDEX") || !strings.Contains(out, "VACUUM FULL") {
+			t.Errorf("terminal(full=%v) dropped a destructive guard:\n%s", full, out)
+		}
+	}
+}

--- a/internal/render/safety_surfaces_test.go
+++ b/internal/render/safety_surfaces_test.go
@@ -5,7 +5,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/fs"
+	"os"
 	"strings"
 	"testing"
 )
@@ -68,42 +68,48 @@ func TestSafety_everySurfaceCarriesGuards(t *testing.T) {
 // is not in coveredSurfaces. Add a new output format, and this fails until it is
 // exercised by the guard-coverage test above.
 func TestSafety_noUndiscoveredSurface(t *testing.T) {
+	// Parse each non-test .go file in the render package (ParseFile, not the
+	// deprecated ParseDir).
 	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, 0)
+	entries, err := os.ReadDir(".")
 	if err != nil {
 		t.Fatal(err)
 	}
 	discovered := 0
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
-			for _, decl := range file.Decls {
-				fn, ok := decl.(*ast.FuncDecl)
-				if !ok || fn.Recv != nil || !fn.Name.IsExported() {
-					continue
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || !fn.Name.IsExported() {
+				continue
+			}
+			if fn.Type.Params == nil || len(fn.Type.Params.List) == 0 {
+				continue
+			}
+			if typeString(fn.Type.Params.List[0].Type) != "io.Writer" {
+				continue
+			}
+			refsContext := false
+			for _, p := range fn.Type.Params.List {
+				if strings.Contains(typeString(p.Type), "model.Context") {
+					refsContext = true
 				}
-				if fn.Type.Params == nil || len(fn.Type.Params.List) == 0 {
-					continue
-				}
-				if typeString(fn.Type.Params.List[0].Type) != "io.Writer" {
-					continue
-				}
-				refsContext := false
-				for _, p := range fn.Type.Params.List {
-					if strings.Contains(typeString(p.Type), "model.Context") {
-						refsContext = true
-					}
-				}
-				if !refsContext {
-					continue
-				}
-				discovered++
-				if !coveredSurfaces[fn.Name.Name] {
-					t.Errorf("output surface %q renders a model.Context but is not covered by the safety-guard "+
-						"coverage test — add it to coveredSurfaces and assert its guard in "+
-						"TestSafety_everySurfaceCarriesGuards, or a destructive warning can ship dropped here.", fn.Name.Name)
-				}
+			}
+			if !refsContext {
+				continue
+			}
+			discovered++
+			if !coveredSurfaces[fn.Name.Name] {
+				t.Errorf("output surface %q renders a model.Context but is not covered by the safety-guard "+
+					"coverage test — add it to coveredSurfaces and assert its guard in "+
+					"TestSafety_everySurfaceCarriesGuards, or a destructive warning can ship dropped here.", fn.Name.Name)
 			}
 		}
 	}

--- a/internal/render/safety_surfaces_test.go
+++ b/internal/render/safety_surfaces_test.go
@@ -1,0 +1,130 @@
+package render
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+// coveredSurfaces are the output/export renderers exercised by
+// TestSafety_everySurfaceCarriesGuards below. TestSafety_noUndiscoveredSurface
+// fails the build if an exported (io.Writer, …model.Context…) renderer exists that
+// is NOT in this set — so a new surface can't ship silently without carrying the
+// destructive-action guards.
+var coveredSurfaces = map[string]bool{
+	"JSON":          true, // structured: full safety object
+	"SARIF":         true, // text message
+	"JUnit":         true, // <failure> text
+	"Terminal":      true, // grouped + --full
+	"Prometheus":    true, // destructive="true" label
+	"PrometheusAll": true, // multi-db variant of Prometheus (same emission)
+}
+
+// TestSafety_everySurfaceCarriesGuards renders a guarded context through every
+// output surface and asserts the destructive-action guard is present — as
+// structured data, text, or a label, whichever the format supports.
+func TestSafety_everySurfaceCarriesGuards(t *testing.T) {
+	render := func(fn func(*bytes.Buffer) error) string {
+		var b bytes.Buffer
+		if err := fn(&b); err != nil {
+			t.Fatal(err)
+		}
+		return b.String()
+	}
+	cases := []struct {
+		surface string
+		out     string
+		want    []string
+	}{
+		{"JSON", render(func(b *bytes.Buffer) error { return JSON(b, guardedContext()) }),
+			[]string{"blocking_caveats", "unused_index.per_node", "DROP INDEX"}},
+		{"SARIF", render(func(b *bytes.Buffer) error { return SARIF(b, guardedContext()) }),
+			[]string{"DROP INDEX", "the index is unused on every replica"}},
+		{"JUnit", render(func(b *bytes.Buffer) error { return JUnit(b, guardedContext(), "warn") }),
+			[]string{"DROP INDEX", "the index is unused on every replica", "VACUUM FULL"}},
+		{"Terminal-grouped", render(func(b *bytes.Buffer) error { return Terminal(b, guardedContext(), Options{Width: 100}) }),
+			[]string{"DROP INDEX", "VACUUM FULL"}},
+		{"Terminal-full", render(func(b *bytes.Buffer) error { return Terminal(b, guardedContext(), Options{Full: true, Width: 100}) }),
+			[]string{"DROP INDEX", "VACUUM FULL"}},
+		{"Prometheus", render(func(b *bytes.Buffer) error { return Prometheus(b, guardedContext()) }),
+			[]string{`destructive="true"`}},
+	}
+	for _, tc := range cases {
+		for _, w := range tc.want {
+			if !strings.Contains(tc.out, w) {
+				t.Errorf("%s surface dropped the guard: missing %q", tc.surface, w)
+			}
+		}
+	}
+}
+
+// TestSafety_noUndiscoveredSurface is the auto-discovery backstop: it scans the
+// render package for exported renderers — an exported package-level func whose
+// first parameter is io.Writer and which takes a model.Context — and fails if any
+// is not in coveredSurfaces. Add a new output format, and this fails until it is
+// exercised by the guard-coverage test above.
+func TestSafety_noUndiscoveredSurface(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	discovered := 0
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Recv != nil || !fn.Name.IsExported() {
+					continue
+				}
+				if fn.Type.Params == nil || len(fn.Type.Params.List) == 0 {
+					continue
+				}
+				if typeString(fn.Type.Params.List[0].Type) != "io.Writer" {
+					continue
+				}
+				refsContext := false
+				for _, p := range fn.Type.Params.List {
+					if strings.Contains(typeString(p.Type), "model.Context") {
+						refsContext = true
+					}
+				}
+				if !refsContext {
+					continue
+				}
+				discovered++
+				if !coveredSurfaces[fn.Name.Name] {
+					t.Errorf("output surface %q renders a model.Context but is not covered by the safety-guard "+
+						"coverage test — add it to coveredSurfaces and assert its guard in "+
+						"TestSafety_everySurfaceCarriesGuards, or a destructive warning can ship dropped here.", fn.Name.Name)
+				}
+			}
+		}
+	}
+	// Guard against a vacuous pass (a broken scan that discovers nothing).
+	if discovered < 5 {
+		t.Fatalf("surface scan found only %d renderers — expected ≥5 (JSON/SARIF/JUnit/Terminal/Prometheus…); the AST scan is broken", discovered)
+	}
+}
+
+// typeString renders a small subset of type expressions (enough for io.Writer,
+// *model.Context, []*model.Context) to a string.
+func typeString(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.SelectorExpr:
+		return typeString(t.X) + "." + t.Sel.Name
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return "*" + typeString(t.X)
+	case *ast.ArrayType:
+		return "[]" + typeString(t.Elt)
+	}
+	return ""
+}

--- a/internal/render/sarif.go
+++ b/internal/render/sarif.go
@@ -98,12 +98,21 @@ func securityScore(f *model.Finding) string {
 	}
 }
 
-// resultMessage is the per-result text: the title, plus the first caveat and the
-// remediation so an alert is actionable without leaving GitHub.
+// resultMessage is the per-result text: the title, the remediation, and — for a
+// destructive-action finding — its structured safety guards, so a DROP INDEX /
+// VACUUM FULL warning is never lost on the way to the GitHub Security tab.
 func resultMessage(f *model.Finding) string {
 	msg := f.Title
 	if f.Remediation != "" {
 		msg += " — " + f.Remediation
+	}
+	if f.Safety != nil {
+		for _, g := range f.Safety.BlockingCaveats {
+			msg += " SAFETY [" + g.Action + "]: " + g.Text
+			if g.Verify != nil {
+				msg += " Only after: " + *g.Verify
+			}
+		}
 	}
 	return msg
 }

--- a/internal/render/sarif.go
+++ b/internal/render/sarif.go
@@ -106,13 +106,8 @@ func resultMessage(f *model.Finding) string {
 	if f.Remediation != "" {
 		msg += " — " + f.Remediation
 	}
-	if f.Safety != nil {
-		for _, g := range f.Safety.BlockingCaveats {
-			msg += " SAFETY [" + g.Action + "]: " + g.Text
-			if g.Verify != nil {
-				msg += " Only after: " + *g.Verify
-			}
-		}
+	if s := safetyText(f); s != "" {
+		msg += " " + s
 	}
 	return msg
 }

--- a/internal/render/terminal.go
+++ b/internal/render/terminal.go
@@ -251,6 +251,7 @@ func renderFindings(b *strings.Builder, st styler, fs []model.Finding, width int
 				fmt.Fprintf(b, "     %s\n", st.dim(prefix+line))
 			}
 		}
+		renderSafetyGuards(b, st, f, width, "     ")
 		// Every finding references its catalogue page — offline via the subcommand.
 		fmt.Fprintf(b, "     %s\n", st.dim("docs: pgbot explain-finding "+f.ID))
 	}

--- a/internal/render/testdata/sample.prom
+++ b/internal/render/testdata/sample.prom
@@ -1,9 +1,9 @@
-# HELP pgbot_finding A pgbot finding (1 = present). suppressed="true" means muted by .pgbot.toml.
+# HELP pgbot_finding A pgbot finding (1 = present). suppressed="true" means muted by .pgbot.toml; destructive="true" means it carries a safety guard against a destructive action.
 # TYPE pgbot_finding gauge
-pgbot_finding{database="app",id="fsync_off",severity="critical",dimension="risk",object="setting:fsync",suppressed="false"} 1
-pgbot_finding{database="app",id="unused_indexes",severity="warn",dimension="storage",object="",suppressed="false"} 1
-pgbot_finding{database="app",id="io_timing_off",severity="info",dimension="throughput",object="setting:track_io_timing",suppressed="false"} 1
-pgbot_finding{database="app",id="checksums_disabled",severity="info",dimension="risk",object="setting:data_checksums",suppressed="true"} 1
+pgbot_finding{database="app",id="fsync_off",severity="critical",dimension="risk",object="setting:fsync",suppressed="false",destructive="false"} 1
+pgbot_finding{database="app",id="unused_indexes",severity="warn",dimension="storage",object="",suppressed="false",destructive="false"} 1
+pgbot_finding{database="app",id="io_timing_off",severity="info",dimension="throughput",object="setting:track_io_timing",suppressed="false",destructive="false"} 1
+pgbot_finding{database="app",id="checksums_disabled",severity="info",dimension="risk",object="setting:data_checksums",suppressed="true",destructive="false"} 1
 # HELP pgbot_findings_total Active (unsuppressed) findings by severity.
 # TYPE pgbot_findings_total gauge
 pgbot_findings_total{database="app",severity="critical"} 1

--- a/internal/store/migrations/006_index_verdicts.sql
+++ b/internal/store/migrations/006_index_verdicts.sql
@@ -1,0 +1,16 @@
+-- Agent code-search verdicts for indexes (index/code correlation). A verdict is
+-- an agent's answer to "is this index's column referenced in query filters in the
+-- repo?", recorded against a database + index so that on later runs a still-unused
+-- index over a longer window carries strengthening evidence rather than starting
+-- from scratch. New table only — nothing existing is touched. Idempotent, so it
+-- re-runs harmlessly on every store open.
+CREATE TABLE IF NOT EXISTS index_verdicts (
+    fingerprint       TEXT    NOT NULL,
+    index_id          TEXT    NOT NULL, -- schema.index
+    verdict           TEXT    NOT NULL, -- not_found_in_code | found_in_code | inconclusive
+    source            TEXT,             -- e.g. agent_repo_search
+    repo_ref          TEXT,             -- optional commit sha
+    checked_at        INTEGER NOT NULL, -- unix seconds
+    stats_window_days REAL,             -- window length when the verdict was recorded
+    PRIMARY KEY (fingerprint, index_id)
+);

--- a/internal/store/verdicts.go
+++ b/internal/store/verdicts.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"database/sql"
+	"time"
+)
+
+// IndexVerdict is one recorded code-search result for an index (index/code
+// correlation). It is the compounding half of the feature: a one-off grep is a
+// one-off, but a verdict stored against a growing stats window gets stronger.
+type IndexVerdict struct {
+	IndexID         string    // schema.index
+	Verdict         string    // not_found_in_code | found_in_code | inconclusive
+	Source          string    // e.g. agent_repo_search
+	RepoRef         string    // optional commit sha
+	CheckedAt       time.Time // when the search was run
+	StatsWindowDays *float64  // window length at the time, for "evidence strengthened"
+}
+
+// SaveIndexVerdict upserts one verdict for (fingerprint, index). Re-recording the
+// same index replaces the prior verdict — the latest code search wins.
+func (s *Store) SaveIndexVerdict(fingerprint string, v IndexVerdict) error {
+	var win sql.NullFloat64
+	if v.StatsWindowDays != nil {
+		win = sql.NullFloat64{Float64: *v.StatsWindowDays, Valid: true}
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO index_verdicts (fingerprint, index_id, verdict, source, repo_ref, checked_at, stats_window_days)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(fingerprint, index_id) DO UPDATE SET
+		  verdict = excluded.verdict, source = excluded.source, repo_ref = excluded.repo_ref,
+		  checked_at = excluded.checked_at, stats_window_days = excluded.stats_window_days`,
+		fingerprint, v.IndexID, v.Verdict, v.Source, v.RepoRef, v.CheckedAt.UTC().Unix(), win)
+	return err
+}
+
+// LoadIndexVerdicts returns every stored verdict for a database, keyed by
+// index_id (schema.index).
+func (s *Store) LoadIndexVerdicts(fingerprint string) (map[string]IndexVerdict, error) {
+	rows, err := s.db.Query(`
+		SELECT index_id, verdict, source, repo_ref, checked_at, stats_window_days
+		FROM index_verdicts WHERE fingerprint = ?`, fingerprint)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]IndexVerdict{}
+	for rows.Next() {
+		var (
+			v      IndexVerdict
+			source sql.NullString
+			ref    sql.NullString
+			ts     int64
+			win    sql.NullFloat64
+		)
+		if err := rows.Scan(&v.IndexID, &v.Verdict, &source, &ref, &ts, &win); err != nil {
+			return nil, err
+		}
+		v.Source, v.RepoRef = source.String, ref.String
+		v.CheckedAt = time.Unix(ts, 0).UTC()
+		if win.Valid {
+			w := win.Float64
+			v.StatsWindowDays = &w
+		}
+		out[v.IndexID] = v
+	}
+	return out, rows.Err()
+}

--- a/internal/store/verdicts_test.go
+++ b/internal/store/verdicts_test.go
@@ -1,0 +1,82 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func openTemp(t *testing.T) *Store {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "b.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}
+
+func TestIndexVerdict_roundTripAndUpsert(t *testing.T) {
+	s := openTemp(t)
+	win := 12.0
+	v := IndexVerdict{
+		IndexID: "public.Job_externalIdNormalized_idx", Verdict: "not_found_in_code",
+		Source: "agent_repo_search", RepoRef: "abc123",
+		CheckedAt: time.Unix(1_700_000_000, 0), StatsWindowDays: &win,
+	}
+	if err := s.SaveIndexVerdict("fp1", v); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := s.LoadIndexVerdicts("fp1")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	g, ok := got["public.Job_externalIdNormalized_idx"]
+	if !ok {
+		t.Fatal("verdict not loaded")
+	}
+	if g.Verdict != "not_found_in_code" || g.RepoRef != "abc123" || g.StatsWindowDays == nil || *g.StatsWindowDays != 12 {
+		t.Errorf("round-trip mismatch: %+v", g)
+	}
+
+	// Upsert: re-record the same index with a newer verdict + wider window.
+	win2 := 26.0
+	if err := s.SaveIndexVerdict("fp1", IndexVerdict{
+		IndexID: v.IndexID, Verdict: "found_in_code", CheckedAt: time.Unix(1_800_000_000, 0), StatsWindowDays: &win2,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got, _ = s.LoadIndexVerdicts("fp1")
+	if len(got) != 1 {
+		t.Fatalf("upsert must replace, not duplicate: %d rows", len(got))
+	}
+	if got[v.IndexID].Verdict != "found_in_code" || *got[v.IndexID].StatsWindowDays != 26 {
+		t.Errorf("latest verdict should win: %+v", got[v.IndexID])
+	}
+}
+
+func TestIndexVerdict_isolatedByFingerprint(t *testing.T) {
+	s := openTemp(t)
+	_ = s.SaveIndexVerdict("fpA", IndexVerdict{IndexID: "public.a", Verdict: "found_in_code", CheckedAt: time.Now()})
+	_ = s.SaveIndexVerdict("fpB", IndexVerdict{IndexID: "public.b", Verdict: "not_found_in_code", CheckedAt: time.Now()})
+	a, _ := s.LoadIndexVerdicts("fpA")
+	if len(a) != 1 || a["public.a"].Verdict != "found_in_code" {
+		t.Errorf("fpA leaked or wrong: %+v", a)
+	}
+	if _, ok := a["public.b"]; ok {
+		t.Error("fpB verdict must not appear under fpA")
+	}
+}
+
+// The new migration must not disturb existing tables — a Save/List on snapshots
+// still works after 006 is applied.
+func TestMigration006_leavesExistingTablesUsable(t *testing.T) {
+	s := openTemp(t)
+	if _, err := s.LoadIndexVerdicts("none"); err != nil {
+		t.Fatalf("index_verdicts table should exist and be queryable: %v", err)
+	}
+	// suppression_rules (005) still works.
+	if _, err := s.RecordSuppressionUsage("fp", nil, nil, time.Now()); err != nil {
+		t.Fatalf("existing suppression table broke after 006: %v", err)
+	}
+}

--- a/schema/pgbot-context-1.2.0.json
+++ b/schema/pgbot-context-1.2.0.json
@@ -1,0 +1,1644 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pgbot.dev/schema/pgbot-context-1.2.0.json",
+  "$ref": "#/$defs/Context",
+  "$defs": {
+    "Activity": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "active": {
+          "type": "integer"
+        },
+        "idle": {
+          "type": "integer"
+        },
+        "idle_in_transaction": {
+          "type": "integer"
+        },
+        "waiting": {
+          "type": "integer"
+        },
+        "by_state": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "wait_events": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "longest_xact_sec": {
+          "type": "number"
+        },
+        "longest_active_sec": {
+          "type": "number"
+        },
+        "connections": {
+          "items": {
+            "$ref": "#/$defs/ConnGroup"
+          },
+          "type": "array"
+        },
+        "autovacuum_workers": {
+          "type": "integer"
+        },
+        "autovacuum_max_age_sec": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness",
+        "total",
+        "active",
+        "idle",
+        "idle_in_transaction",
+        "waiting",
+        "by_state",
+        "longest_xact_sec",
+        "longest_active_sec"
+      ]
+    },
+    "Archiver": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "archived_count": {
+          "type": "integer"
+        },
+        "last_archived_wal": {
+          "type": "string"
+        },
+        "last_archived_time": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "failed_count": {
+          "type": "integer"
+        },
+        "last_failed_wal": {
+          "type": "string"
+        },
+        "last_failed_time": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "stats_reset": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "has_archive_command": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness",
+        "archived_count",
+        "failed_count",
+        "has_archive_command"
+      ]
+    },
+    "BlockingRow": {
+      "properties": {
+        "blocked_pid": {
+          "type": "integer"
+        },
+        "blocking_pids": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "wait_event": {
+          "type": "string"
+        },
+        "wait_seconds": {
+          "type": "number"
+        },
+        "blocked_query": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "blocked_pid",
+        "blocking_pids",
+        "wait_seconds",
+        "blocked_query"
+      ]
+    },
+    "ChecksumFailure": {
+      "properties": {
+        "database": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer"
+        },
+        "last_failure": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "database",
+        "count"
+      ]
+    },
+    "Checksums": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "failures": {
+          "items": {
+            "$ref": "#/$defs/ChecksumFailure"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness"
+      ]
+    },
+    "ConnGroup": {
+      "properties": {
+        "app_name": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "app_name",
+        "user",
+        "state",
+        "count"
+      ]
+    },
+    "Context": {
+      "properties": {
+        "schema_version": {
+          "type": "string"
+        },
+        "profile": {
+          "type": "string"
+        },
+        "collected_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "fingerprint": {
+          "type": "string"
+        },
+        "server": {
+          "$ref": "#/$defs/ServerInfo"
+        },
+        "window": {
+          "$ref": "#/$defs/Window"
+        },
+        "health": {
+          "$ref": "#/$defs/Health"
+        },
+        "activity": {
+          "$ref": "#/$defs/Activity"
+        },
+        "locks": {
+          "$ref": "#/$defs/Locks"
+        },
+        "queries": {
+          "$ref": "#/$defs/Queries"
+        },
+        "tables": {
+          "$ref": "#/$defs/Tables"
+        },
+        "indexes": {
+          "$ref": "#/$defs/Indexes"
+        },
+        "wal": {
+          "$ref": "#/$defs/WAL"
+        },
+        "io": {
+          "$ref": "#/$defs/IO"
+        },
+        "replication": {
+          "$ref": "#/$defs/Replication"
+        },
+        "settings": {
+          "$ref": "#/$defs/Settings"
+        },
+        "limits": {
+          "$ref": "#/$defs/Limits"
+        },
+        "horizon": {
+          "$ref": "#/$defs/VacuumHorizon"
+        },
+        "sequences": {
+          "$ref": "#/$defs/Sequences"
+        },
+        "progress": {
+          "$ref": "#/$defs/Progress"
+        },
+        "archiver": {
+          "$ref": "#/$defs/Archiver"
+        },
+        "checksums": {
+          "$ref": "#/$defs/Checksums"
+        },
+        "standby": {
+          "$ref": "#/$defs/StandbyStatus"
+        },
+        "deltas": {
+          "$ref": "#/$defs/Deltas"
+        },
+        "delta_suppressed_reason": {
+          "type": "string"
+        },
+        "events": {
+          "items": {
+            "$ref": "#/$defs/Event"
+          },
+          "type": "array"
+        },
+        "wait_profile": {
+          "$ref": "#/$defs/WaitProfile"
+        },
+        "findings": {
+          "items": {
+            "$ref": "#/$defs/Finding"
+          },
+          "type": "array"
+        },
+        "config_warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "schema_version",
+        "collected_at",
+        "fingerprint",
+        "server",
+        "window",
+        "findings"
+      ]
+    },
+    "Delta": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "subject": {
+          "type": "string"
+        },
+        "severity": {
+          "type": "string"
+        },
+        "before": {
+          "type": "number"
+        },
+        "after": {
+          "type": "number"
+        },
+        "pct_change": {
+          "type": "number"
+        },
+        "first_observed": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "note": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "subject",
+        "severity",
+        "before",
+        "after"
+      ]
+    },
+    "Deltas": {
+      "properties": {
+        "against": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "yesterday_hour": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "changes": {
+          "items": {
+            "$ref": "#/$defs/Delta"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "against",
+        "changes"
+      ]
+    },
+    "Event": {
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "before": {
+          "type": "string"
+        },
+        "after": {
+          "type": "string"
+        },
+        "occurred_after": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "occurred_before": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "confidence": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "kind",
+        "confidence"
+      ]
+    },
+    "Finding": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "severity": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "detail": {
+          "type": "string"
+        },
+        "evidence": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "objects": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "remediation": {
+          "type": "string"
+        },
+        "impact": {
+          "$ref": "#/$defs/Impact"
+        },
+        "confidence": {
+          "type": "number"
+        },
+        "caveats": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "related": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "suppressed": {
+          "type": "boolean"
+        },
+        "suppression_reason": {
+          "type": "string"
+        },
+        "suppression_rule": {
+          "type": "string"
+        },
+        "severity_remapped": {
+          "type": "string"
+        },
+        "cluster_scoped": {
+          "type": "boolean"
+        },
+        "preexisting": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "severity",
+        "title",
+        "detail",
+        "impact",
+        "confidence"
+      ]
+    },
+    "Health": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "connections": {
+          "type": "integer"
+        },
+        "tps": {
+          "type": "number"
+        },
+        "commits_per_sec": {
+          "type": "number"
+        },
+        "rollbacks_per_sec": {
+          "type": "number"
+        },
+        "rollback_ratio": {
+          "type": "number"
+        },
+        "cache_hit_ratio": {
+          "type": "number"
+        },
+        "cache_blocks_sampled": {
+          "type": "integer"
+        },
+        "deadlocks_per_min": {
+          "type": "number"
+        },
+        "temp_bytes_per_sec": {
+          "type": "number"
+        },
+        "tuples_returned_per_sec": {
+          "type": "number"
+        },
+        "tuples_written_per_sec": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness",
+        "connections"
+      ]
+    },
+    "HorizonHolder": {
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "holder": {
+          "type": "string"
+        },
+        "xmin_age": {
+          "type": "integer"
+        },
+        "age_s": {
+          "type": "number"
+        },
+        "detail": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "source",
+        "holder",
+        "xmin_age"
+      ]
+    },
+    "IO": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "checkpoints_timed": {
+          "type": "integer"
+        },
+        "checkpoints_requested": {
+          "type": "integer"
+        },
+        "buffers_written_per_sec": {
+          "type": "number"
+        },
+        "backend_fsyncs": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness",
+        "checkpoints_timed",
+        "checkpoints_requested",
+        "backend_fsyncs"
+      ]
+    },
+    "Impact": {
+      "properties": {
+        "score": {
+          "type": "number"
+        },
+        "dimension": {
+          "type": "string"
+        },
+        "estimate": {
+          "type": "string"
+        },
+        "basis": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "score",
+        "dimension",
+        "estimate",
+        "basis"
+      ]
+    },
+    "IndexStat": {
+      "properties": {
+        "schema": {
+          "type": "string"
+        },
+        "table": {
+          "type": "string"
+        },
+        "index": {
+          "type": "string"
+        },
+        "scans": {
+          "type": "integer"
+        },
+        "bytes": {
+          "type": "integer"
+        },
+        "definition": {
+          "type": "string"
+        },
+        "columns": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "method": {
+          "type": "string"
+        },
+        "unique": {
+          "type": "boolean"
+        },
+        "primary": {
+          "type": "boolean"
+        },
+        "partial": {
+          "type": "boolean"
+        },
+        "expression": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "schema",
+        "table",
+        "index",
+        "scans",
+        "bytes"
+      ]
+    },
+    "Indexes": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "total": {
+          "type": "integer"
+        },
+        "scanned": {
+          "type": "integer"
+        },
+        "unused": {
+          "items": {
+            "$ref": "#/$defs/IndexStat"
+          },
+          "type": "array"
+        },
+        "largest": {
+          "items": {
+            "$ref": "#/$defs/IndexStat"
+          },
+          "type": "array"
+        },
+        "redundant": {
+          "items": {
+            "$ref": "#/$defs/RedundantIndex"
+          },
+          "type": "array"
+        },
+        "unindexed_fks": {
+          "items": {
+            "$ref": "#/$defs/UnindexedFK"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness",
+        "total",
+        "scanned"
+      ]
+    },
+    "Limits": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "connections_used": {
+          "type": "integer"
+        },
+        "connections_max": {
+          "type": "integer"
+        },
+        "max_xid_age": {
+          "type": "integer"
+        },
+        "max_mxid_age": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness",
+        "connections_used",
+        "connections_max",
+        "max_xid_age"
+      ]
+    },
+    "Locks": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "blocked_count": {
+          "type": "integer"
+        },
+        "chains": {
+          "items": {
+            "$ref": "#/$defs/BlockingRow"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness",
+        "blocked_count"
+      ]
+    },
+    "NarrowIdentityColumn": {
+      "properties": {
+        "schema": {
+          "type": "string"
+        },
+        "table": {
+          "type": "string"
+        },
+        "column": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "schema",
+        "table",
+        "column",
+        "type"
+      ]
+    },
+    "PartitionRollup": {
+      "properties": {
+        "schema": {
+          "type": "string"
+        },
+        "table": {
+          "type": "string"
+        },
+        "partitions": {
+          "type": "integer"
+        },
+        "total_bytes": {
+          "type": "integer"
+        },
+        "live_tuples": {
+          "type": "integer"
+        },
+        "seq_scans": {
+          "type": "integer"
+        },
+        "index_scans": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "schema",
+        "table",
+        "partitions",
+        "total_bytes",
+        "live_tuples",
+        "seq_scans",
+        "index_scans"
+      ]
+    },
+    "Progress": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "operations": {
+          "items": {
+            "$ref": "#/$defs/ProgressOp"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness"
+      ]
+    },
+    "ProgressOp": {
+      "properties": {
+        "pid": {
+          "type": "integer"
+        },
+        "operation": {
+          "type": "string"
+        },
+        "relation": {
+          "type": "string"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "pct": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "pid",
+        "operation"
+      ]
+    },
+    "Queries": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "total_exec_ms": {
+          "type": "number"
+        },
+        "pgss_dealloc": {
+          "type": "integer"
+        },
+        "pgss_count": {
+          "type": "integer"
+        },
+        "pgss_max": {
+          "type": "integer"
+        },
+        "top": {
+          "items": {
+            "$ref": "#/$defs/QueryStat"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness",
+        "enabled"
+      ]
+    },
+    "QueryStat": {
+      "properties": {
+        "queryid": {
+          "type": "integer"
+        },
+        "query": {
+          "type": "string"
+        },
+        "calls": {
+          "type": "integer"
+        },
+        "total_ms": {
+          "type": "number"
+        },
+        "mean_ms": {
+          "type": "number"
+        },
+        "max_ms": {
+          "type": "number"
+        },
+        "rows": {
+          "type": "integer"
+        },
+        "cache_hit": {
+          "type": "number"
+        },
+        "wal_bytes": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "queryid",
+        "query",
+        "calls",
+        "total_ms",
+        "mean_ms",
+        "max_ms",
+        "rows",
+        "wal_bytes"
+      ]
+    },
+    "QueryWaits": {
+      "properties": {
+        "query_id": {
+          "type": "integer"
+        },
+        "sample_text": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer"
+        },
+        "share": {
+          "type": "number"
+        },
+        "lock_share": {
+          "type": "number"
+        },
+        "io_share": {
+          "type": "number"
+        },
+        "top_type": {
+          "type": "string"
+        },
+        "top_event": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "query_id",
+        "count",
+        "share",
+        "lock_share",
+        "io_share"
+      ]
+    },
+    "RedundantIndex": {
+      "properties": {
+        "schema": {
+          "type": "string"
+        },
+        "table": {
+          "type": "string"
+        },
+        "index": {
+          "type": "string"
+        },
+        "covered_by": {
+          "type": "string"
+        },
+        "bytes": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "schema",
+        "table",
+        "index",
+        "covered_by",
+        "bytes"
+      ]
+    },
+    "ReplicaRow": {
+      "properties": {
+        "client_addr": {
+          "type": "string"
+        },
+        "application_name": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "sync_state": {
+          "type": "string"
+        },
+        "sync_priority": {
+          "type": "integer"
+        },
+        "replay_lag_sec": {
+          "type": "number"
+        },
+        "write_lag_bytes": {
+          "type": "integer"
+        },
+        "flush_lag_bytes": {
+          "type": "integer"
+        },
+        "replay_lag_bytes": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "client_addr",
+        "state",
+        "sync_state",
+        "write_lag_bytes",
+        "flush_lag_bytes",
+        "replay_lag_bytes"
+      ]
+    },
+    "Replication": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "is_replica": {
+          "type": "boolean"
+        },
+        "replicas": {
+          "items": {
+            "$ref": "#/$defs/ReplicaRow"
+          },
+          "type": "array"
+        },
+        "receiver_lag_sec": {
+          "type": "number"
+        },
+        "slots": {
+          "items": {
+            "$ref": "#/$defs/ReplicationSlot"
+          },
+          "type": "array"
+        },
+        "subscriptions": {
+          "items": {
+            "$ref": "#/$defs/Subscription"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness",
+        "is_replica"
+      ]
+    },
+    "ReplicationSlot": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "database": {
+          "type": "string"
+        },
+        "retained_bytes": {
+          "type": "integer"
+        },
+        "wal_status": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "type",
+        "active",
+        "retained_bytes"
+      ]
+    },
+    "SequenceUsage": {
+      "properties": {
+        "schema": {
+          "type": "string"
+        },
+        "sequence": {
+          "type": "string"
+        },
+        "last_value": {
+          "type": "integer"
+        },
+        "ceiling": {
+          "type": "integer"
+        },
+        "pct_used": {
+          "type": "number"
+        },
+        "owned_by": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "schema",
+        "sequence",
+        "last_value",
+        "ceiling",
+        "pct_used"
+      ]
+    },
+    "Sequences": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "items": {
+          "items": {
+            "$ref": "#/$defs/SequenceUsage"
+          },
+          "type": "array"
+        },
+        "narrow_identity": {
+          "items": {
+            "$ref": "#/$defs/NarrowIdentityColumn"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness"
+      ]
+    },
+    "ServerInfo": {
+      "properties": {
+        "version_num": {
+          "type": "integer"
+        },
+        "version_text": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "in_recovery": {
+          "type": "boolean"
+        },
+        "via_pooler": {
+          "type": "boolean"
+        },
+        "started_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "uptime_seconds": {
+          "type": "integer"
+        },
+        "extensions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "capabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "has_pg_monitor": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "version_num",
+        "version_text",
+        "database",
+        "uptime_seconds",
+        "extensions",
+        "capabilities",
+        "has_pg_monitor"
+      ]
+    },
+    "Settings": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "overrides": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "params": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness",
+        "overrides"
+      ]
+    },
+    "StandbyStatus": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "confl_tablespace": {
+          "type": "integer"
+        },
+        "confl_lock": {
+          "type": "integer"
+        },
+        "confl_snapshot": {
+          "type": "integer"
+        },
+        "confl_bufferpin": {
+          "type": "integer"
+        },
+        "confl_deadlock": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness",
+        "confl_tablespace",
+        "confl_lock",
+        "confl_snapshot",
+        "confl_bufferpin",
+        "confl_deadlock"
+      ]
+    },
+    "Subscription": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "worker_running": {
+          "type": "boolean"
+        },
+        "last_msg_age_sec": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "worker_running"
+      ]
+    },
+    "TableStat": {
+      "properties": {
+        "schema": {
+          "type": "string"
+        },
+        "table": {
+          "type": "string"
+        },
+        "total_bytes": {
+          "type": "integer"
+        },
+        "live_tuples": {
+          "type": "integer"
+        },
+        "dead_tuples": {
+          "type": "integer"
+        },
+        "dead_ratio": {
+          "type": "number"
+        },
+        "seq_scans": {
+          "type": "integer"
+        },
+        "index_scans": {
+          "type": "integer"
+        },
+        "mods_since_analyze": {
+          "type": "integer"
+        },
+        "updates": {
+          "type": "integer"
+        },
+        "hot_updates": {
+          "type": "integer"
+        },
+        "last_analyze": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_autoanalyze": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "analyze_scale_override": {
+          "type": "number"
+        },
+        "analyze_threshold_override": {
+          "type": "number"
+        },
+        "autovacuum_count": {
+          "type": "integer"
+        },
+        "autovacuum_disabled": {
+          "type": "boolean"
+        },
+        "vacuum_scale_override": {
+          "type": "number"
+        },
+        "vacuum_threshold_override": {
+          "type": "number"
+        },
+        "last_vacuum": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_autovacuum": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "schema",
+        "table",
+        "total_bytes",
+        "live_tuples",
+        "dead_tuples",
+        "dead_ratio",
+        "seq_scans",
+        "index_scans",
+        "mods_since_analyze"
+      ]
+    },
+    "Tables": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "db_size_bytes": {
+          "type": "integer"
+        },
+        "top": {
+          "items": {
+            "$ref": "#/$defs/TableStat"
+          },
+          "type": "array"
+        },
+        "partitioned": {
+          "items": {
+            "$ref": "#/$defs/PartitionRollup"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness",
+        "db_size_bytes"
+      ]
+    },
+    "UnindexedFK": {
+      "properties": {
+        "schema": {
+          "type": "string"
+        },
+        "table": {
+          "type": "string"
+        },
+        "constraint": {
+          "type": "string"
+        },
+        "columns": {
+          "type": "string"
+        },
+        "child_bytes": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "schema",
+        "table",
+        "constraint",
+        "columns",
+        "child_bytes"
+      ]
+    },
+    "VacuumHorizon": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "holders": {
+          "items": {
+            "$ref": "#/$defs/HorizonHolder"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness"
+      ]
+    },
+    "WAL": {
+      "properties": {
+        "exactness": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "bytes_per_sec": {
+          "type": "number"
+        },
+        "records_per_sec": {
+          "type": "number"
+        },
+        "buffers_full": {
+          "type": "integer"
+        },
+        "dir_bytes": {
+          "type": "integer"
+        },
+        "dir_files": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "exactness",
+        "buffers_full"
+      ]
+    },
+    "WaitBucket": {
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer"
+        },
+        "share": {
+          "type": "number"
+        },
+        "events": {
+          "items": {
+            "$ref": "#/$defs/WaitEvent"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "count",
+        "share"
+      ]
+    },
+    "WaitEvent": {
+      "properties": {
+        "event": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer"
+        },
+        "share": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "event",
+        "count",
+        "share"
+      ]
+    },
+    "WaitProfile": {
+      "properties": {
+        "available": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "samples": {
+          "type": "integer"
+        },
+        "window_seconds": {
+          "type": "number"
+        },
+        "buckets": {
+          "items": {
+            "$ref": "#/$defs/WaitBucket"
+          },
+          "type": "array"
+        },
+        "by_query": {
+          "items": {
+            "$ref": "#/$defs/QueryWaits"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "available",
+        "samples",
+        "window_seconds"
+      ]
+    },
+    "Window": {
+      "properties": {
+        "sample_seconds": {
+          "type": "number"
+        },
+        "stats_reset_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "postmaster_start_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "window_age_seconds": {
+          "type": "integer"
+        },
+        "stats_window_days": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "sample_seconds"
+      ]
+    }
+  },
+  "description": "pgbot inspect --json — the versioned Context contract for agents and scripts."
+}

--- a/schema/pgbot-context-1.2.0.json
+++ b/schema/pgbot-context-1.2.0.json
@@ -467,6 +467,9 @@
           },
           "type": "array"
         },
+        "safety": {
+          "$ref": "#/$defs/Safety"
+        },
         "suppressed": {
           "type": "boolean"
         },
@@ -1140,6 +1143,49 @@
         "type",
         "active",
         "retained_bytes"
+      ]
+    },
+    "Safety": {
+      "properties": {
+        "blocking_caveats": {
+          "items": {
+            "$ref": "#/$defs/SafetyGuard"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "blocking_caveats"
+      ]
+    },
+    "SafetyGuard": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "action": {
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        },
+        "verify": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "kind",
+        "action",
+        "text",
+        "verify"
       ]
     },
     "SequenceUsage": {


### PR DESCRIPTION
## What this is

Index/code correlation for unused indexes, and — the larger half — a rebuild of how pgbot delivers **destructive-action warnings** so they are deterministic and can't be dropped on the way to a consumer.

### The finding that started it

A real user's output contained the sentence **"Do not DROP INDEX on this evidence."** `git log -S` shows that literal never existed in the code before this branch. It was **generated by the model** — synthesized from a deterministic per-node caveat plus a docs page. On a different run the model could have omitted it, and a coding agent on the other end would have had no signal not to run an irreversible `DROP INDEX`. We claim deterministic findings; that claim has to be true precisely where a wrong answer damages a production database.

So: every guard against a destructive or irreversible action is now a structured, deterministic field on the finding — never prose a summarizing model can reword away.

## The three parts

**1. Index/code correlation** (`pgbot indexes --correlate`, MCP `index_code_correlation`). Grades each unused / redundant / invalid index by how the drop can be *proven* — `catalog_proven` / `needs_code_check` / `inconclusive` — and, for the actionable ones, hands an agent the exact identifiers to grep (camelCase / snake_case / PascalCase / CONSTANT_CASE) with the load-bearing instruction to search **filter** positions only, never SELECT lists. pgbot never reads your repository. Plus `record_index_verdict` write-back so a later run carries the code-search result forward.

**2. Structured destructive-action guards** (`finding.safety`). Every finding whose remediation involves DROP INDEX / VACUUM FULL / REINDEX / DROP REPLICATION SLOT / a table rewrite carries machine-actionable guards — `{id, kind: prohibition|precondition, action, text, verify}`. Emitted in code, guaranteed in `--json`, SARIF, JUnit, a Prometheus `destructive="true"` label, the MCP payloads, and both terminal views. Two guards that previously existed **only in docs pages** (wraparound "don't VACUUM FULL"; "don't drop a slot a live standby depends on") are now on the finding itself. A build-failing test fails CI if a destructive remediation ships without a guard, and an AST scan of the render package fails the build if a new output surface ships without carrying the guards.

**3. Bounded verdict strengthening.** A stored code-search verdict plus a growing observation window is the one place confidence could rise on its own — so a verdict older than the effective observation window is marked **stale**, its age is stated in output, and a stale verdict never strengthens. The strengthened wording reads as *corroboration, not clearance* — the phrases "safe to drop" / "confirmed unused" are asserted absent at every confidence level, and the precondition guard persists through any verdict. An `inconclusive` index is never promoted by any verdict at any window length (tested at a 365-day extreme).

## We rebuilt our own "do not drop" warning — and proved it holds

The model-generated warning is the story. To prove the rebuild, `ask`/`explain` were run against a **mock model that returned the worst possible answer**:

> "Your database has an invalid index and an inactive replication slot wasting space. Just run DROP INDEX on the invalid one and drop the replication slot to reclaim it — **quick and safe, no need to check anything else.**"

pgbot reasserted both guards from code, *after* the model's text:

```
⚠ Safety (from pgbot, not the model) — a destructive action is in scope for this database:
  • [DROP INDEX] … Only after: no CREATE INDEX build is running, then DROP INDEX CONCURRENTLY and rebuild
  • [DROP REPLICATION SLOT] Dropping a slot a live standby or logical subscriber still depends on
    permanently breaks its replication and forces a full resync. Confirm the consumer is truly gone …
```

That test (`ask`/`explain` reasserting guards even when the model says "no need to check anything else") is kept deliberately — it's the whole point of the work.

## ⚠️ Release-note line: human output changes for databases with destructive findings

For a database that has a destructive finding, the **default and `--full` terminal views now add a `⚠` guard line.** This is intentional — the guard was being dropped from the compact view before. **Clean databases are byte-identical.** No `--json` field is removed or renamed; JSON contract bumps `1.1.0 → 1.2.0` (additive: `IndexStat.columns/method/unique/primary`, `finding.safety`), and a 1.1.0 consumer still parses 1.2.0 output.

## Verification

- Unit + model-free tests: per-destructive-finding guard presence across `--json` / SARIF / JUnit / Terminal / Prometheus, keyed on guard **ID** (not text); the build-failing regression + surface auto-discovery guards; the 365-day inconclusive invariant.
- Live PG18 walk-through of the verdict path: fresh verdict → *corroboration, not clearance*; a 60-day-old verdict vs the observation window → **stale, stated, no strengthening**; inconclusive gin + `not_found` verdict → still inconclusive, prohibition intact.
- `scripts/gate.sh` green across 4 arches on HEAD `d24e108`.

### One environment limitation, stated plainly

The prescribed live walk shows a stats window growing 12 days → 40 days. That exact numeric growth was **not** reproduced live: PostgreSQL's `pg_stat_database.stats_reset` cannot be backdated, so a throwaway container's window is either null (warm, via postmaster age) or ~0 (if reset → cold). The end-to-end path (classification → record → read-back → staleness → inconclusive-never-promoted) ran live; the exact 12d→40d *wording* is covered by unit-test output with controlled windows (`internal/correlate` verdict tests). This is an environment limitation, not a skipped check — recorded here so it's clear in six months why this one spot has a unit test where the others have a live run.

## Commits

```
b0c5f69  index/code correlation + confidence levels + verdict store
37c3714  structured, guaranteed destructive-action guards
b8ce536  extend guards to JUnit + Prometheus; auto-discover surfaces
8069857  bound verdict strengthening — staleness + non-authorizing wording
d24e108  judge verdict staleness against the effective window
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
