### PR TITLE
Copilot/update GitHub actions to sha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default: "14 days"
     open-pull-requests-limit: 5
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default: "14 days"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,11 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default: "14 days"
+      default-days: 14
     open-pull-requests-limit: 5
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     cooldown:
-      default: "14 days"
+      default-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     name: vet + unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
       - run: go vet ./...
@@ -36,8 +36,8 @@ jobs:
     name: golangci-lint + govulncheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
       # Pinned to the version validated locally so a golangci-lint release can't
@@ -56,8 +56,8 @@ jobs:
     name: github action smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
       - name: build pgbot onto PATH (so the action uses it — no release needed)
@@ -111,7 +111,7 @@ jobs:
     name: github action install path (latest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: start PostgreSQL with a pg_monitor role
         run: |
           docker run -d --name pg -p 5432:5432 -e POSTGRES_PASSWORD=pw postgres:17
@@ -131,7 +131,7 @@ jobs:
     name: no EXPLAIN ANALYZE
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       # pgbot must never execute a query it inspects. EXPLAIN ANALYZE runs the
       # statement — it must not appear anywhere in the tree.
       - name: forbid EXPLAIN ANALYZE
@@ -154,8 +154,8 @@ jobs:
         goos: [linux, darwin]
         goarch: [amd64, arm64]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
       # CGO must stay off so the binary is static (catches a cgo regression from
@@ -170,8 +170,8 @@ jobs:
       matrix:
         pg: [14, 15, 16, 17, 18]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
       - name: start PostgreSQL ${{ matrix.pg }} (with pg_stat_statements)
@@ -220,8 +220,8 @@ jobs:
     name: transaction pooler (rates stay correct)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v7
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
       - name: PgBouncer transaction mode in front of Postgres
@@ -257,11 +257,11 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
       # DoD 9: exit codes and signals pass through the wrapper unmodified — a 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,24 +15,24 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0 # goreleaser needs full history for the changelog
-      - uses: actions/setup-go@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-      - uses: sigstore/cosign-installer@v3
-      - uses: anchore/sbom-action/download-syft@v0 # goreleaser's sboms block uses syft
-      - uses: docker/setup-qemu-action@v3 # emulation for the linux/arm64 image build
-      - uses: docker/setup-buildx-action@v4 # goreleaser's docker build uses buildx
+      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
+      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0; goreleaser's sboms block uses syft
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0; emulation for the linux/arm64 image build
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0; goreleaser's docker build uses buildx
       # Log in so goreleaser can push the ghcr.io image; without this the docker
       # step fails and takes the whole release (tarballs included) down with it.
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: "~> v2"
           args: release --clean
@@ -51,7 +51,7 @@ jobs:
       # binaries goreleaser just built, and publish them (platform packages first,
       # the wrapper last, since it pins their exact versions). Version == the tag.
       # Skips cleanly when NPM_TOKEN is unset, so a release never fails for it.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
@@ -84,7 +84,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
       - name: npx @pgbot/cli@<tag> --version exits 0
@@ -161,7 +161,7 @@ jobs:
     name: published signature verifies
     runs-on: ubuntu-latest
     steps:
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
       - name: cosign verify-blob --bundle
         run: |
           VERSION="${GITHUB_REF_NAME}"


### PR DESCRIPTION
## What and why

Pin the GHA workflows to commit sha hashes instead of mutable version tags. Dependabot speaks sha hash natively now, so this has no impact on the usual upgrade flow.

Also adds a cooldown period of 2 weeks for dependabot PRs, since the default is 3 days, and maybe somebody like trivy gets pwned on a Friday at the start of a long weekend and nobody notices till Tuesday.

## Checklist

N/A - Only a GHA CI update 

- [ ] `scripts/gate.sh` passes (builds HEAD, not just the working tree)
- [ ] New SQL is read-only; no `EXPLAIN ANALYZE`; findings stay deterministic (computed in Go)
- [ ] No PII enters a `model.Context` / `--json` / the store
- [ ] `--json` change is additive, or `model.SchemaVersion` bumped + schema regenerated (`go run ./tools/schemagen`)
- [ ] A new finding has a `docs/findings/<id>.md` page + catalog entry
