### PR TITLE
docs(readme): add AUR installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ findings never move them.
 | npx (no install) | `npx @pgbot/cli inspect "$DATABASE_URL"` |
 | Script (cosign signature + checksum) | `curl -fsSL https://pgbot.dev/install \| sh` |
 | Homebrew | `brew install pgrundev/tap/pgbot` |
+| Arch User Repository | `yay -S pgbot-bin` |
 | Go | `go install github.com/pgrundev/pgbot/cmd/pgbot@latest` |
 | Docker | `docker run --rm ghcr.io/pgrundev/pgbot inspect "$DATABASE_URL"` |
 | Windows / manual | download the archive for your OS/arch from [Releases](https://github.com/pgrundev/pgbot/releases) (Linux/macOS `.tar.gz`, Windows `.zip`) |


### PR DESCRIPTION
Add installation instructions for the Arch User Repository (AUR) to the README.
I have started maintaining a package for pgbot in the AUR and it would be helpful for AUR users.
