### PR TITLE
Add FUNDING.yml: Sponsor button → github.com/sponsors/pgrundev

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: pgrundev


### PR DESCRIPTION
Adds `.github/FUNDING.yml` with `github: pgrundev` so the repository shows a **Sponsor** button pointing at https://github.com/sponsors/pgrundev.

No external payment services are listed. The button becomes useful once the `pgrundev` GitHub Sponsors profile is approved and public.
