### PR TITLE
ci: build the windows targets goreleaser already ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,8 +150,10 @@ jobs:
     name: build ${{ matrix.goos }}/${{ matrix.goarch }}
     runs-on: ubuntu-latest
     strategy:
+      # Every target .goreleaser.yaml ships — a release must not be the first
+      # thing that compiles a platform.
       matrix:
-        goos: [linux, darwin]
+        goos: [linux, darwin, windows]
         goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.db-shm
 pgrun_metrcis2.mp4
 /pgbot
+/pgbot.exe
 
 # npm packaging build output (assembled by npm/build.mjs)
 npm/staging/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,9 @@ scripts/gate.sh                # the real gate — builds HEAD, not your working
 ```
 
 `scripts/gate.sh` refuses a dirty tree, then builds and tests the committed HEAD
-in an isolated clone across four arches. Run it before pushing — a green
-working-tree `go test` can hide a partial commit that doesn't compile.
+in an isolated clone across every released target (linux, darwin and windows ×
+amd64, arm64). Run it before pushing — a green working-tree `go test` can hide a
+partial commit that doesn't compile.
 
 Integration tests run against a real database when `PGBOT_TEST_DSN` (a superuser
 DSN unlocks the doc-verify guard via `PGBOT_TEST_SUPERUSER_DSN`) is set:

--- a/scripts/gate.sh
+++ b/scripts/gate.sh
@@ -36,13 +36,14 @@ command -v golangci-lint >/dev/null || {
 }
 golangci-lint run ./...
 CGO_ENABLED=0 go test ./...
-for goos in linux darwin; do
+# Every target .goreleaser.yaml ships, windows included.
+for goos in linux darwin windows; do
   for goarch in amd64 arm64; do
     CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build -o /dev/null ./cmd/pgbot
   done
 done
 popd >/dev/null
-echo "✓ HEAD builds, vets, and tests clean (4 arches)"
+echo "✓ HEAD builds, vets, and tests clean (6 targets)"
 
 # (3) "Green" must mean CI, not just local — surface the latest main conclusion.
 if command -v gh >/dev/null 2>&1; then


### PR DESCRIPTION
## What and why

`.goreleaser.yaml` ships `[linux, darwin, windows] × [amd64, arm64]`, but the CI
build matrix and `scripts/gate.sh` both stop at linux and darwin — so no Windows
target compiles anywhere until the release job runs at tag time. That's the same
"green somewhere else hid a break" failure mode `gate.sh` exists to prevent.

- CI matrix and `gate.sh` now build every released target — 6 instead of 4, still
  `CGO_ENABLED=0` cross-compiles on `ubuntu-latest` (no Windows runner minutes).
- `.gitignore` gains `/pgbot.exe`: a root `go build ./cmd/pgbot` emits that name on
  Windows, `/pgbot` doesn't match it, so Windows contributors start with a dirty
  tree — which `gate.sh` then refuses to gate.

No change to the binary's behavior.

## Verification

windows/amd64, Go 1.27.1, golangci-lint 2.13.2, rebased on current `main`:

```
$ scripts/gate.sh
✓ HEAD builds, vets, and tests clean (6 targets)
```

## Checklist

- [x] `scripts/gate.sh` passes (builds HEAD, not just the working tree)
- Remaining items n/a — no SQL, no `model.Context`/`--json` change, no new finding.
