### PR TITLE
Integrate nixpks build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,21 @@ jobs:
           fi
           echo "clean: no EXPLAIN ANALYZE"
 
+  nix:
+    name: nix build
+    # vendorHash changes with every dependency bump, so this job is
+    # informational — a red nix build must not block an otherwise green PR.
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: nix build .#pgbot
+      # proves the ldflags version stamp reached the packaged binary
+      - run: ./result/bin/pgbot --version | grep -q 'pgbot version 0\.'
+
   build:
     name: build ${{ matrix.goos }}/${{ matrix.goarch }}
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ pgrun_metrcis2.mp4
 
 # npm packaging build output (assembled by npm/build.mjs)
 npm/staging/
+
+result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,4 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+pkgs.callPackage ./package.nix { }

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,0 @@
-{
-  pkgs ? import <nixpkgs> { },
-}:
-pkgs.callPackage ./package.nix { }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,44 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f (
+            import nixpkgs {
+              inherit system;
+              overlays = [ self.overlays.default ];
+            }
+          )
+        );
+    in
+    {
+      overlays.default = final: prev: {
+        pgbot = final.callPackage ./package.nix { };
+      };
+
+      packages = forAllSystems (pkgs: rec {
+        pgbot = pkgs.pgbot;
+        default = pgbot;
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            go_1_27
+            golangci-lint
+          ];
+        };
+      });
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  go_1_27,
+}:
+(buildGoModule.override { go = go_1_27; }) (finalAttrs: {
+  pname = "pgbot";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "pgrundev";
+    repo = "pgbot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QJWJTSS92g7Ay2r5yckbRX5/JOUIBDTKGXpEzerZyKI=";
+  };
+
+  vendorHash = "sha256-iN6SE0ehjVVXkw8hHsUrCNXPV1Xchw6gxt92kVCQTV4=";
+
+  subPackages = [ "cmd/pgbot" ];
+
+  env.CGO_ENABLED = "0";
+
+  ldflags = [
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "In-database observability for PostgreSQL";
+    longDescription = ''
+      pgbot is a read-only PostgreSQL observability CLI. A single static
+      binary connects with a read-only role, reads Postgres's own
+      statistics views, and prints findings-first health reports plus
+      diffs against previous runs. No agent, no external service, no
+      write privilege anywhere in the path.
+    '';
+    homepage = "https://github.com/pgrundev/pgbot";
+    changelog = "https://github.com/pgrundev/pgbot/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "pgbot";
+  };
+})

--- a/scripts/gate.sh
+++ b/scripts/gate.sh
@@ -22,7 +22,9 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
 # (2) Build and test from HEAD, isolated from the working tree.
-git clone --quiet --local . "$tmp"
+# --no-hardlinks: TMPDIR is often tmpfs (e.g. under `nix develop`) and
+# hardlinking the clone fails across filesystems.
+git clone --quiet --local --no-hardlinks . "$tmp"
 pushd "$tmp" >/dev/null
 echo "→ gating HEAD ($head) in an isolated clone"
 CGO_ENABLED=0 go build ./...


### PR DESCRIPTION
## What and why

<!-- What does this change, and why? -->

## Checklist

- [x] `scripts/gate.sh` passes (builds HEAD, not just the working tree)
- [N/A] New SQL is read-only; no `EXPLAIN ANALYZE`; findings stay deterministic (computed in Go)
- [x] No PII enters a `model.Context` / `--json` / the store
- [ N/A] `--json` change is additive, or `model.SchemaVersion` bumped + schema regenerated (`go run ./tools/schemagen`)
- [N/A] A new finding has a `docs/findings/<id>.md` page + catalog entry


 ### nix: flake packaging (go_1_27, v0.8.1) + non-blocking nix CI

   Adds nix packaging so `nix build .#pgbot` / `nix run .#pgbot` works, plus an
   informational nix build in CI. Rebased on current main; hashes recomputed for v0.8.1.

   **Packaging** (`flake.nix`, `package.nix`)
   - `buildGoModule` pinned to `go_1_27`: nixpkgs-unstable's default go (1.26.x)
     can't satisfy the module's `go 1.27` directive
   - `ldflags = -X main.version=` → packaged binary reports `pgbot version 0.8.1`, not `dev`
   - devShell (`nix develop`) ships go 1.27.1 + golangci-lint

   **CI** (`.github/workflows/ci.yml`)
   - new `nix build` job with `continue-on-error: true` — vendorHash changes at each
     release tag, so a stale hash must annotate, never block a PR

   **Incidental:** `scripts/gate.sh` local clone now uses `--no-hardlinks` — the
   hardlink step fails on tmpfs `TMPDIR` (tmpfs `/tmp`, `nix develop`, WSL2). Cost
   is one ~12 MB copy, freed on exit. Also gitignores `/result`.

   **Validation**
   - `nix build .#pgbot` → `./result/bin/pgbot --version` → `pgbot version 0.8.1`
   - `nix develop -c scripts/gate.sh` green (build, vet, golangci-lint, tests, 4 cross-builds)


closes #31 
